### PR TITLE
Image and Button cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### New features/enhancements:
 
+### Bug fixes:
+- Images now handle errors and render null instead of broken link [#212](https://github.com/ndlib/usurper/pull/212)
+- Button on my items page will now link no matter where you click [#212](https://github.com/ndlib/usurper/pull/212)
+
+
 ## [0.9](https://github.com/ndlib/usurper/tree/v0.9.0) (In development)
 [Full Changelog](https://github.com/ndlib/usurper/compare/v0.8.0...v0.9.0)
 

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,6 +1,8 @@
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
 
-import Image from './presenter'
+import Presenter from './presenter'
 
 export const mapStateToProps = (state, thisProps) => {
   let src = thisProps.src
@@ -15,10 +17,53 @@ export const mapStateToProps = (state, thisProps) => {
 
   if (!alt) {
     alt = ''
-    hidden=true
+    hidden = true
   }
 
   return { src: src, alt: alt, className: thisProps.className, ariaHidden: hidden }
 }
 
-export default connect(mapStateToProps)(Image)
+export class ImageContainer extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      error: false,
+    }
+    this.onError = this.onError.bind(this)
+  }
+
+  onError () {
+    this.setState({ error: true })
+  }
+
+  render () {
+    if (!this.props.src) {
+      return null
+    }
+
+    if (this.state.error) {
+      return null
+    }
+
+    return <Presenter
+      src={this.props.src}
+      alt={this.props.alt}
+      className={this.props.className}
+      ariaHidden={this.props.ariaHidden}
+      onError={this.onError}
+    />
+  }
+}
+
+ImageContainer.propTypes = {
+  src: PropTypes.string,
+  className: PropTypes.string,
+  alt: PropTypes.string,
+  ariaHidden: PropTypes.bool,
+
+  // removed in mapping
+  cfImage: PropTypes.object,
+  defaultImage: PropTypes.string,
+}
+
+export default connect(mapStateToProps)(ImageContainer)

--- a/src/components/Image/presenter.js
+++ b/src/components/Image/presenter.js
@@ -2,12 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const Image = (props) => {
-  if (!props.src) {
-    return null
-  }
   return (
     <div className='frame'>
-      <img className={props.className} src={props.src} alt={props.alt} aria-hidden={props.ariaHidden} />
+      <img className={props.className} src={props.src} alt={props.alt} aria-hidden={props.ariaHidden} onError={props.onError} />
     </div>
   )
 }
@@ -18,9 +15,7 @@ Image.propTypes = {
   alt: PropTypes.string,
   ariaHidden: PropTypes.bool,
 
-  // removed in container
-  cfImage: PropTypes.object,
-  defaultImage: PropTypes.string,
+  onError: PropTypes.func,
 }
 
 export default Image

--- a/src/components/LoanResources/illiadActions.js
+++ b/src/components/LoanResources/illiadActions.js
@@ -15,21 +15,23 @@ const IlliadActions = ({ item }) => {
   let webButton = null
   if (item.status === 'Delivered to Web') {
     webButton = (
-      <button>
-        <Link to={Config.illiadBaseURL.replace('<<form>>', illWebForm).replace('<<value>>', item.transactionNumber)}>
-          View On Web
-        </Link>
-      </button>
+      <Link
+        to={Config.illiadBaseURL.replace('<<form>>', illWebForm).replace('<<value>>', item.transactionNumber)}
+        className='button'
+      >
+        View On Web
+      </Link>
     )
   }
 
   return (
     <div className={item.title + 'illiadActions'}>
-      <button>
-        <Link to={Config.illiadBaseURL.replace('<<form>>', illViewForm).replace('<<value>>', item.transactionNumber)}>
-          View in ILL
-        </Link>
-      </button>
+      <Link
+        to={Config.illiadBaseURL.replace('<<form>>', illViewForm).replace('<<value>>', item.transactionNumber)}
+        className='button'
+      >
+        View in ILL
+      </Link>
       { webButton }
     </div>
   )

--- a/src/tests/components/Image/presenter.test.js
+++ b/src/tests/components/Image/presenter.test.js
@@ -20,9 +20,9 @@ describe('components/Image/index.js', () => {
   })
 
   describe('with no src', () => {
-    it('should return null', () => {
+    it('should return image with no source', () => {
       setup({})
-      expect(enzymeWrapper.equals(null)).toBe(true)
+      expect(enzymeWrapper.containsMatchingElement(<img src={undefined} />)).toBe(true)
     })
   })
 


### PR DESCRIPTION
- Images now handle errors (like 404) and render null instead of a broken image link
- Buttons on the items page should now link no matter where you click on it