### PR TITLE
Bugfix: Search preferences

### DIFF
--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -39,16 +39,22 @@ const setSearchType = (newState) => {
   newState.searchType = 'ONESEARCH'
 }
 
-export default (
-  state = {
+const defaultState = () => {
+  let state = {
     drawerOpen: true,
-    searchType: 'ONESEARCH',
+    searchType: null,
     searchBoxOpen: false,
     advancedSearch: false,
     hasPref: localSearchPref !== null,
     usePref: true,
     pref: JSON.parse(localSearchPref) || null,
-  },
+  }
+  setSearchType(state)
+  return state
+}
+
+export default (
+  state = defaultState(),
   action
 ) => {
   switch (action.type) {


### PR DESCRIPTION
The users local search preference was not always being honored. The problem specifically exhibited itself on initial page load, if on a page that never fired any actions that the search reducer cared about (ex: the root page). This was due to the fact that the initial state in the reducer was not applying the rules that we specified, and no other actions were getting called to apply those rules.

Changes:
- Changed the default state to apply the rules defined in setSearchType
- Changed the default state searchType to null. Nothing should officially set this value except for the setSearchType function, so setting it to null initially should hopefully indicate a problem if we forget to call setSearchType in the future.