### PR TITLE
Hide search drawer image on homepage when closed

### DIFF
--- a/src/components/SearchDrawer/presenter.js
+++ b/src/components/SearchDrawer/presenter.js
@@ -35,7 +35,7 @@ const SearchDrawer = (props) => {
   if (props.search.drawerOpen) {
     return <Drawer {...props} />
   } else {
-    return (<section id='drawer' role='Search' aria-hidden='true' />)
+    return (<section id='drawer' role='Search' aria-hidden='true' className='hidden' />)
   }
 }
 


### PR DESCRIPTION
Comment can’t be empty, but needs to be hidden when closed.