### PR TITLE
Bugfix case of the mondays

### DIFF
--- a/src/components/Hours/Current/collapsed_presenter.js
+++ b/src/components/Hours/Current/collapsed_presenter.js
@@ -11,13 +11,12 @@ const Presenter = (hoursEntry, isOpen, expandHandler, children) => {
   return (
     <section className={servicePointClassName} aria-label={title}>
       <a
-        id='expand_hours'
         className='expand'
         tabIndex={0}
         onClick={expandHandler}
         onKeyDown={expandHandler}
         aria-expanded={false}
-        aria-controls={hoursEntry.name}
+        aria-controls={hoursEntry.servicePoint.slug}
       >
         <h4>
           <div className='location'>{hoursEntry.name}</div>
@@ -27,7 +26,7 @@ const Presenter = (hoursEntry, isOpen, expandHandler, children) => {
           </div>
         </h4>
       </a>
-      <div id={hoursEntry.name} aria-hidden={true} />
+      <div id={hoursEntry.servicePoint.slug} aria-hidden={true} />
     </section>
   )
 }

--- a/src/components/Hours/Current/expanded_presenter.js
+++ b/src/components/Hours/Current/expanded_presenter.js
@@ -7,17 +7,15 @@ const Presenter = (hoursEntry, isOpen, collapseHandler, children) => {
   const title = 'Hours for ' + hoursEntry.name
   const servicePointClassName = 'service-point ' + (isOpen ? 'open' : 'closed')
   const todayLabel = 'Today: ' + hoursEntry.today.display
-
   return (
     <section className={servicePointClassName} aria-label={title}>
       <a
-        id='collapse_hours'
         className='collapse'
         tabIndex={0}
         onClick={collapseHandler}
         onKeyDown={collapseHandler}
         aria-expanded={true}
-        aria-controls={hoursEntry.name}
+        aria-controls={hoursEntry.servicePoint.slug}
       >
         <h4>
           <div className='location'>{hoursEntry.name}</div>
@@ -27,7 +25,7 @@ const Presenter = (hoursEntry, isOpen, collapseHandler, children) => {
           </div>
         </h4>
       </a>
-      <div className='row hours-listing' id={hoursEntry.name}>
+      <div className='row hours-listing' id={hoursEntry.servicePoint.slug}>
         <div className='col-md-4'>
           <WeeklyHours hours={hoursEntry.thisWeek} title='Current Hours' showEffectiveDates={false} />
           <WeeklyHours hours={hoursEntry.upcomingDifferentHours} title='Upcoming Hours' showEffectiveDates />

--- a/src/components/Hours/Current/index.js
+++ b/src/components/Hours/Current/index.js
@@ -70,10 +70,15 @@ export class CurrentHoursContainer extends Component {
   checkOpen (props) {
     try {
       const entry = props.hoursEntry
-      const opens = timeToday(entry.today.date, entry.today.opens)
-      const closes = timeToday(entry.today.date, entry.today.closes)
-      const now = new Date()
-      return opens <= now && now <= closes
+      const currentOpenBlocks = entry.today.hours.filter(hoursBlock => {
+        let opens = timeToday(hoursBlock.date, hoursBlock.opens)
+        let closes = timeToday(hoursBlock.date, hoursBlock.closes)
+        let now = new Date()
+        if (opens <= now && now <= closes) {
+          return true
+        }
+      })
+      return (currentOpenBlocks.length > 0)
     } catch (e) {
       return false
     }

--- a/src/components/Hours/InlineContainer/index.js
+++ b/src/components/Hours/InlineContainer/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import * as statuses from '../../../constants/APIStatuses'
 
-class InlineContainer extends Component {
+class HoursInlineContainer extends Component {
   render () {
     switch (this.props.hoursEntry.status) {
       case statuses.FETCHING:
@@ -15,12 +15,11 @@ class InlineContainer extends Component {
   }
 }
 
-InlineContainer.propTypes = {
+HoursInlineContainer.propTypes = {
   hoursEntry: PropTypes.object.isRequired,
   presenter: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,
-  children: PropTypes.object,
   toggleExpanded: PropTypes.func,
 }
 
-export default InlineContainer
+export default HoursInlineContainer

--- a/src/components/Hours/Page/index.js
+++ b/src/components/Hours/Page/index.js
@@ -17,7 +17,6 @@ const hoursPageOrder = [
   { servicePointSlug: 'architecturelibrary', main: true },
   { servicePointSlug: 'byzantinestudiesreadingroom', main: true },
   { servicePointSlug: 'centerfordigitalscholarship', main: true },
-  { servicePointSlug: 'centerfordigitalscholarshiprooms', main: false },
   { servicePointSlug: 'chemistryphysicslibrary', main: true },
   { servicePointSlug: 'engineeringlibrary', main: true },
   { servicePointSlug: 'kelloggkroclibrary', main: true },
@@ -25,6 +24,7 @@ const hoursPageOrder = [
   { servicePointSlug: 'medievalinstitutelibrary', main: true },
   { servicePointSlug: 'musiclibrary', main: true },
   { servicePointSlug: 'radiationchemistryreadingroom', main: true },
+  { servicePointSlug: 'universityarchives', main: true },
   { servicePointSlug: 'visualresourcescenter', main: true },
 ]
 


### PR DESCRIPTION
This contains necessary code changes to fix missing Monday data and "Today: undefined" bugs on the hours page. This does require data changes in libcal before it will be fully fixed. Changes:
- The API will now always return an array for blocks of hours. Changed components to read through the array of hours blocks to see if any of them mean the location is open
- Was getting warnings about how children were passed into the InlineContainer for hours. Some components were sending arrays. We likely shouldn't need to create expectations on children here since we never consume them in anyway other than to just render them as is. Removed it from the proptypes
- Changed the naming of the export in the hours InlineContainer to be a little more descriptive, just so that it's a little quicker to see what's happening in stack traces in the future.
- Fixed the unique dom ids and dom ids with spaces bugs on the hours page
- At Julie's request, removed CDS scholarship rooms and added Archives

Note: This depends on https://github.com/ndlib/monarch_libguides/pull/14