### PR TITLE
Math Library + Safari Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New features/enhancements:
 
 ### Bug fixes:
+- Add Math library to hours page [#225](https://github.com/ndlib/usurper/pull/225)
+- Fix Safari hours coloring [#225](https://github.com/ndlib/usurper/pull/225)
 
 ## [0.10](https://github.com/ndlib/usurper/tree/master) (2017-7-26)
 [Full Changelog](https://github.com/ndlib/usurper/compare/v0.9.0...v0.10.0)

--- a/src/components/Hours/Current/index.js
+++ b/src/components/Hours/Current/index.js
@@ -12,9 +12,14 @@ import InlineContainer from '../InlineContainer'
 // Parses date/time from the strings given in an hoursEntry.
 const timeToday = (dateString, timeString) => {
   // This does not account for time zone differences
-  let utcMs = Date.parse(dateString + 'T' + timeString)
-  let date = new Date(utcMs)
-  return date
+  // We have to split the strings instead of concating as [date]T[time] because different browsers
+  //   parse the timezone differently if it's not defined (UTC vs local)
+  //   while all handle constructors the same (always local)
+  let dateArray = dateString.split('-')
+  let timeArray = timeString.split(':')
+  // Month is month - 1 because date month is 0 based
+  return new Date(Number(dateArray[0]), Number(dateArray[1]) - 1, Number(dateArray[2]),
+                          Number(timeArray[0]), Number(timeArray[1]))
 }
 
 // We  need a way to give each instance of a container access to its own private selector.

--- a/src/components/Hours/Page/index.js
+++ b/src/components/Hours/Page/index.js
@@ -21,6 +21,7 @@ const hoursPageOrder = [
   { servicePointSlug: 'chemistryphysicslibrary', main: true },
   { servicePointSlug: 'engineeringlibrary', main: true },
   { servicePointSlug: 'kelloggkroclibrary', main: true },
+  { servicePointSlug: 'omearamathematicslibrary', main:true },
   { servicePointSlug: 'medievalinstitutelibrary', main: true },
   { servicePointSlug: 'byzantinestudiesreadingroom', main: false },
   { servicePointSlug: 'musiclibrary', main: true },


### PR DESCRIPTION
- Add math library to hours page
- Fix safari coloring, was parsing as UTC instead of local time zone