### PR TITLE
Update redirects

### DIFF
--- a/src/components/App/Rewrite/index.js
+++ b/src/components/App/Rewrite/index.js
@@ -4,9 +4,17 @@ import { Route, Redirect } from 'react-router'
 
 const Rewrite = (props) => {
   return RedirectRoutes.map((route, index) => {
-    const forwardPath = route.forwardPath ? props.location.pathname : ''
+    let path = ''
+    if (route.forwardPath) {
+      let found = props.location.pathname.match(route.forwardPath)
+      if (found) {
+        path = found[1]
+      }
+    }
+
     const forwardSearch = route.forwardQuery ? props.location.search : ''
-    const target = route.target + forwardPath + forwardSearch
+    const target = route.target + path + forwardSearch
+
     // external redirect
     if (route.target.indexOf('http') === 0) {
       return (

--- a/src/components/App/Rewrite/redirectRoutes.js
+++ b/src/components/App/Rewrite/redirectRoutes.js
@@ -20,6 +20,7 @@ const RedirectRoutes = [
   { path: '/utilities/acquisitions/order', target: 'https://factotum.library.nd.edu/utilities/forms/purchase/new' },
   { path: '/utilities/*', target: 'https://factotum.library.nd.edu', forwardPath: /(.*)/, forwardQuery: true },
   { path: '/guide-on-the-side/*', target: 'https://guide-on-the-side.library.nd.edu', forwardPath: /\/guide-on-the-side(.*)/ },
+  { path: '/documents/*', target: 'https://documents.library.nd.edu', forwardPath: /\/documents(.*)/ },
   { path: '/eresources/*', target: 'https://eresources.library.nd.edu', forwardPath: /\/eresources(.*)/ },
 
   // internal redirects

--- a/src/components/App/Rewrite/redirectRoutes.js
+++ b/src/components/App/Rewrite/redirectRoutes.js
@@ -1,8 +1,9 @@
 const RedirectRoutes = [
   // external redirects
   { path: '/cds', target: 'http://cds.library.nd.edu' },
+  { path: '/cds/*', target: 'http://cds.library.nd.edu', forwardPath: /\/cds(.*)/ },
   { path: '/directory', target: 'https://directory.library.nd.edu' },
-  { path: '/directory/*', target: 'https://directory.library.nd.edu', forwardPath: true },
+  { path: '/directory/*', target: 'https://directory.library.nd.edu', forwardPath: /(.*)/ },
   { path: '/ill', target: 'https://nd.illiad.oclc.org/illiad/IND/illiad.dll' },
   { path: '/docdel', target: 'https://nd.illiad.oclc.org/illiad/IND/illiad.dll' },
   { path: '/ovgtsl2018', target: 'http://ovgtsl2018.library.nd.edu' },
@@ -17,7 +18,9 @@ const RedirectRoutes = [
   { path: '/GLSBC2016/', target: 'http://glsbc2016.library.nd.edu/' },
   { path: '/instruction/potofgold', target: 'https://potofgold.library.nd.edu' },
   { path: '/utilities/acquisitions/order', target: 'https://factotum.library.nd.edu/utilities/forms/purchase/new' },
-  { path: '/utilities/*', target: 'https://factotum.library.nd.edu', forwardPath: true, forwardQuery: true },
+  { path: '/utilities/*', target: 'https://factotum.library.nd.edu', forwardPath: /(.*)/, forwardQuery: true },
+  { path: '/guide-on-the-side/*', target: 'https://guide-on-the-side.library.nd.edu', forwardPath: /\/guide-on-the-side(.*)/ },
+  { path: '/eresources/*', target: 'https://eresources.library.nd.edu', forwardPath: /\/eresources(.*)/ },
 
   // internal redirects
   { path: '/biochemistry', target: '/chemistry' },
@@ -38,6 +41,7 @@ const RedirectRoutes = [
   // wild card redirects
   { path: '/srch-find/*', target: '/research' },
   { path: '/circulation/*', target: '/services' },
+  { path: '/about/hours/*', target: '/hours' },
 
 ]
 export default RedirectRoutes


### PR DESCRIPTION
Allow forwarding only part of the path via regex. EG. `/cds/foo/bar` will only forward `/foo/bar` with the regex `/\/cds(.*)/`