### PR TITLE
Mh courses unit test

### DIFF
--- a/src/components/Courses/index.js
+++ b/src/components/Courses/index.js
@@ -16,7 +16,7 @@ const get = (dict, key, defaultVal) => {
   return dict[key]
 }
 
-class CoursesContainer extends Component {
+export class CoursesContainer extends Component {
   checkLoggedIn (props) {
     if (props.courses.state === statuses.NOT_FETCHED &&
       props.loggedIn) {

--- a/src/tests/components/Courses/index.test.js
+++ b/src/tests/components/Courses/index.test.js
@@ -2,14 +2,14 @@ import * as statuses from '../../../constants/APIStatuses'
 import { mapStateToProps } from '../../../components/Courses'
 
 describe('components/Courses/index.js', () => {
-  describe('with data', () => {
+  describe('with correct data', () => {
     let state = {
       personal: {
         login: {
           state: statuses.SUCCESS,
         },
+        courses: ['courses']
       },
-      courses: ['courses']
     }
 
     let ownProp = {
@@ -29,7 +29,31 @@ describe('components/Courses/index.js', () => {
     })
 
     it('should have courses', () => {
-      expect(mapStateToProps(state, ownProp).courses).toEqual(['courses'])
+      expect(mapStateToProps(state, ownProp).courses).toEqual(state.personal.courses)
     })
-  }
-}
+  })
+
+  describe('with incorrect data', () => {
+    let state = {
+      personal: {
+        login: {
+          state: statuses.NOT_FOUND,
+        },
+      },
+    }
+
+    let ownProp = {}
+
+    it('should identify if the user is logged in', () => {
+      expect(mapStateToProps(state, ownProp).loggedIn).toBe(false)
+    })
+
+    it('should not be previewable', () => {
+      expect(mapStateToProps(state, ownProp).preview).toBe(false)
+    })
+
+    it('should not have courses', () => {
+      expect(mapStateToProps(state, ownProp).courses).toEqual({state: statuses.NOT_FETCHED})
+    })
+  })
+})

--- a/src/tests/components/Courses/index.test.js
+++ b/src/tests/components/Courses/index.test.js
@@ -1,7 +1,120 @@
+import React from 'react'
 import * as statuses from '../../../constants/APIStatuses'
 import { mapStateToProps } from '../../../components/Courses'
+import CoursesPresenter from '../../../components/Courses/presenter'
+import { mount, shallow } from 'enzyme'
+import { CoursesContainer } from '../../../components/Courses'
+import Link from '../../../components/Link'
+import Loading from '../../../components/Messages/Loading'
 
-describe('components/Courses/index.js', () => {
+const setup = (props) => {
+  return shallow(<CoursesContainer {...props} />, { lifecycleExperimental: true })
+}
+
+let enzymeWrapper
+let props
+describe('components/Courses/index.js -- CoursesContainer', () => {
+  describe('Courses Container - not link only', () => {
+    beforeEach(() => {
+      props = {
+        linkOnly: false,
+        preview: true,
+        loggedIn: false,
+        login: {
+          redirectUrl: '',
+          token: 'fake token',
+          state: statuses.SUCCESS,
+        },
+        courses: {
+          state: statuses.SUCCESS,
+        },
+      }
+      enzymeWrapper = setup(props)
+    })
+
+    afterEach(() => {
+      enzymeWrapper = undefined
+    })
+
+    it('renders Courses Presenter', () => {
+      expect(enzymeWrapper
+        .containsMatchingElement(<CoursesPresenter {...props} />))
+        .toBe(true)
+    })
+  })
+
+  describe('Courses Container - not link only', () => {
+    beforeEach(() => {
+      props = {
+        linkOnly: true,
+        preview: true,
+        loggedIn: false,
+        login: {
+          redirectUrl: '',
+          token: 'fake token',
+          state: statuses.SUCCESS,
+        },
+        courses: {
+          state: statuses.SUCCESS,
+        },
+      }
+      enzymeWrapper = setup(props)
+    })
+
+    afterEach(() => {
+      enzymeWrapper = undefined
+    })
+
+    it('does not render Courses Presenter', () => {
+      expect(enzymeWrapper
+        .containsMatchingElement(<CoursesPresenter {...props} />))
+        .toBe(false)
+    })
+
+    it('only renders a link', () => {
+      expect(enzymeWrapper
+        .containsMatchingElement(<Link to='/courses' className='button fright tab'>My Courses</Link>))
+        .toBe(true)
+    })
+  })
+
+  describe('Courses Container - Loading', () => {
+    beforeEach(() => {
+      props = {
+        linkOnly: false,
+        preview: true,
+        loggedIn: false,
+        login: {
+          redirectUrl: '',
+          token: 'fake token',
+          state: statuses.SUCCESS,
+        },
+        courses: {
+          state: statuses.NOT_FETCHED,
+        },
+      }
+      enzymeWrapper = setup(props)
+    })
+
+    afterEach(() => {
+      enzymeWrapper = undefined
+    })
+
+    it('does not render Courses Presenter', () => {
+      expect(enzymeWrapper
+        .containsMatchingElement(<CoursesPresenter {...props} />))
+        .toBe(false)
+    })
+
+    it('renders Loading html', () => {
+      expect(enzymeWrapper
+        .containsMatchingElement(<Loading />))
+        .toBe(true)
+    })
+  })
+})
+
+describe('components/Courses/index.js -- mapStateToProps', () => {
   describe('with correct data', () => {
     let state = {
       personal: {

--- a/src/tests/components/Courses/index.test.js
+++ b/src/tests/components/Courses/index.test.js
@@ -73,7 +73,7 @@ describe('components/Courses/index.js -- CoursesContainer', () => {
 
     it('only renders a link', () => {
       expect(enzymeWrapper
-        .containsMatchingElement(<Link to='/courses' className='button fright tab'>My Courses</Link>))
+        .containsMatchingElement(<Link to='/courses'>My Courses</Link>))
         .toBe(true)
     })
   })
@@ -137,7 +137,7 @@ describe('components/Courses/index.js -- mapStateToProps', () => {
       expect(mapStateToProps(state, ownProp).loggedIn).toBe(true)
     })
 
-    it('should be previewable', () => {
+    it('should use preview content', () => {
       expect(mapStateToProps(state, ownProp).preview).toBe(true)
     })
 
@@ -161,7 +161,7 @@ describe('components/Courses/index.js -- mapStateToProps', () => {
       expect(mapStateToProps(state, ownProp).loggedIn).toBe(false)
     })
 
-    it('should not be previewable', () => {
+    it('should not use preview content', () => {
       expect(mapStateToProps(state, ownProp).preview).toBe(false)
     })
 

--- a/src/tests/components/Courses/index.test.js
+++ b/src/tests/components/Courses/index.test.js
@@ -1,0 +1,35 @@
+import * as statuses from '../../../constants/APIStatuses'
+import { mapStateToProps } from '../../../components/Courses'
+
+describe('components/Courses/index.js', () => {
+  describe('with data', () => {
+    let state = {
+      personal: {
+        login: {
+          state: statuses.SUCCESS,
+        },
+      },
+      courses: ['courses']
+    }
+
+    let ownProp = {
+      location: {
+        search: {
+          preview: 'true'
+        },
+      },
+    }
+
+    it('should identify if the user is logged in', () => {
+      expect(mapStateToProps(state, ownProp).loggedIn).toBe(true)
+    })
+
+    it('should be previewable', () => {
+      expect(mapStateToProps(state, ownProp).preview).toBe(true)
+    })
+
+    it('should have courses', () => {
+      expect(mapStateToProps(state, ownProp).courses).toEqual(['courses'])
+    })
+  }
+}


### PR DESCRIPTION
Creates the test for the Courses/index.js file.  Uses the enzyme wrapper to test the Courses Container based on possible outcomes in the index.js file. Also adds export to the Courses Container class declaration because otherwise it cannot be tested.

Then, tests the mapStateToProps functionality  by using two props, "state" and "ownProp".  Tests with correct data and incorrect data.