### PR TITLE
Add programmatic Google Analytics for search

### DIFF
--- a/config/configurationGen.js
+++ b/config/configurationGen.js
@@ -11,6 +11,7 @@ const genConfig = () => {
     contentfulAPI: 'https://bj5rh8poa7.execute-api.us-east-1.amazonaws.com/dev',
     serviceNowBaseURL: 'https://nd.service-now.com/nd_portal?id=sc_cat_item&sys_id=1198d67ddb4a7240de73f5161d961936',
     version: 'dev',
+    googleAnalyticsId: 'UA-2118378-47',
   }
 
   let config = {
@@ -23,6 +24,7 @@ const genConfig = () => {
     contentfulAPI: process.env.CONTENTFUL_API ? process.env.CONTENTFUL_API : defaultConfig.contentfulAPI,
     serviceNowBaseURL: process.env.SERVICE_NOW_BASE_URL ? process.env.SERVICE_NOW_BASE_URL : defaultConfig.serviceNowBaseURL,
     version: process.env.VERSION ? process.env.VERSION : defaultConfig.version,
+    googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID ? process.env.GOOGLE_ANALYTICS_ID : defaultConfig.googleAnalyticsId,
   }
 
   return { __APP_CONFIG__: JSON.stringify(config) }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-ga": "^2.2.0",
     "react-redux": "^5.0.4",
     "react-router": "^4.1.1",
     "react-router-config": "^1.0.0-beta.3",

--- a/src/components/SearchDrawer/SearchBox/index.js
+++ b/src/components/SearchDrawer/SearchBox/index.js
@@ -5,10 +5,23 @@ import { openSearchBox, closeSearchBox } from '../../../actions/search.js'
 import { setSearchOption } from '../../../actions/advancedSearch.js'
 import searchQuery from '../searchQueryBuilder'
 import SearchBox from './presenter'
+import ReactGA from 'react-ga'
+import Config from '../../../shared/Configuration'
+ReactGA.initialize(Config.googleAnalyticsId, {
+  debug: false,
+  titleCase: false,
+  gaOptions: {},
+})
+
 const mapStateToProps = (state, ownProps) => {
   return {
     onSubmit: (e) => {
       e.preventDefault()
+      ReactGA.event({
+        category: `LIBRARY WEBSITE SEARCH SUBMISSION`,
+        action: `${state.search.searchType}`,
+        label: `${state.advancedSearch['basic-search-field']}`,
+      })
       searchQuery(state.search, state.advancedSearch)
     },
     ...state,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,7 +1595,7 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
-create-react-class@^15.6.0:
+create-react-class@^15.5.2, create-react-class@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
   dependencies:
@@ -4882,7 +4882,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -5000,6 +5000,14 @@ react-dom@^15.5.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-ga@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.2.0.tgz#45235de1356e4d988d9b82214d615a08489c9291"
+  dependencies:
+    create-react-class "^15.5.2"
+    object-assign "^4.0.1"
+    prop-types "^15.5.6"
 
 react-redux@^5.0.4:
   version "5.0.6"


### PR DESCRIPTION
We currently have no way to actually track search usage on the new site. This should resolve that by creating a custom Google Analytics tracking event.

Note: This is only tracking the basic search right now. I'm unsure if there's any utility for Kate to track the advanced search.

* Add react-ga for programmatic tracking
* On submission of search form, submit a custom event that details
which search type was selected and the query parameters