### PR TITLE
Multiple Service Points on Pages

### DIFF
--- a/src/components/Contentful/Page/presenter.js
+++ b/src/components/Contentful/Page/presenter.js
@@ -66,7 +66,7 @@ const PagePresenter = ({ cfPageEntry }) => (
         <PageLink className='button callout' cfPage={cfPageEntry.fields.callOutLink} />
         <Librarians netids={cfPageEntry.fields.contactPeople} />
         {
-          cfPageEntry.fields.servicePoints.map((point, index) => {
+          cfPageEntry.fields.servicePoints && cfPageEntry.fields.servicePoints.map((point, index) => {
             return <ServicePoint cfServicePoint={point} key={index + '_point'} />
           })
         }

--- a/src/components/Contentful/Page/presenter.js
+++ b/src/components/Contentful/Page/presenter.js
@@ -23,11 +23,17 @@ const PagePresenter = ({ cfPageEntry }) => (
         <div className='sp-hidden'><ServicePoint cfServicePoint={cfPageEntry.fields.servicePoint} /></div>
         <LibMarkdown>{ cfPageEntry.fields.body }</LibMarkdown>
 
-        <Related className='p-resources' title={ cfPageEntry.fields.relatedResourcesTitleOverride ? cfPageEntry.fields.relatedResourcesTitleOverride : 'Resources' } showImages={false}>{ cfPageEntry.fields.relatedResources }</Related>
+        <Related
+          className='p-resources'
+          title={ cfPageEntry.fields.relatedResourcesTitleOverride ? cfPageEntry.fields.relatedResourcesTitleOverride : 'Resources' }
+          showImages={false}
+        >
+          { cfPageEntry.fields.relatedResources }
+        </Related>
         <Related className='p-guides' title='Guides' showTitle={false} showImages={false}>{ cfPageEntry.fields.libguides }</Related>
         <Related className='p-services' title='Services'>{ cfPageEntry.fields.relatedServices }</Related>
         {
-          cfPageEntry.fields.relatedExtraSections && cfPageEntry.fields.relatedExtraSections.map((entry) => {
+          cfPageEntry.fields.relatedExtraSections && cfPageEntry.fields.relatedExtraSections.map((entry, index) => {
             let fields = entry.fields
             let className = 'p-resources'
             let showImages = false
@@ -42,7 +48,16 @@ const PagePresenter = ({ cfPageEntry }) => (
                   break
               }
             }
-            return <Related className={className} title={fields.title} showImages={showImages}>{ fields.links }</Related>
+            return (
+              <Related
+                className={className}
+                title={fields.title}
+                showImages={showImages}
+                key={index + '_related'}
+              >
+                { fields.links }
+              </Related>
+            )
           })
         }
       </section>
@@ -50,8 +65,18 @@ const PagePresenter = ({ cfPageEntry }) => (
         <Image cfImage={cfPageEntry.fields.image} className='cover' />
         <PageLink className='button callout' cfPage={cfPageEntry.fields.callOutLink} />
         <Librarians netids={cfPageEntry.fields.contactPeople} />
-        <ServicePoint cfServicePoint={cfPageEntry.fields.servicePoint} />
-        <Related className='p-pages' title='Related Pages' showImages={false}>{ cfPageEntry.fields.relatedPages }</Related>
+        {
+          cfPageEntry.fields.servicePoints.map((point, index) => {
+            return <ServicePoint cfServicePoint={point} key={index + '_point'} />
+          })
+        }
+        <Related
+          className='p-pages'
+          title='Related Pages'
+          showImages={false}
+        >
+          { cfPageEntry.fields.relatedPages }
+        </Related>
       </section>
     </div>
   </div>

--- a/src/components/Home/News/index.js
+++ b/src/components/Home/News/index.js
@@ -23,8 +23,6 @@ export const sortNews = (left, right) => {
 const mapStateToProps = (state) => {
   let allNews = []
   if (state.allNews && state.allNews.status === statuses.SUCCESS) {
-    let now = new Date()
-
     allNews = state.allNews.json
       .map((entry) => {
         flattenLocale(entry.fields, 'en-US')


### PR DESCRIPTION
Use `servicePoints` field (list) instead of `servicePoint` (single), to allow for multiple points to show on pages

This requires a change in contentful data upon deployment -- it's already been made in dev, and I have a script to update the entries in prod. I did already add the field in prod, just haven't updated the entries yet.