### PR TITLE
Fix hours color display

### DIFF
--- a/src/components/Hours/Current/expanded_presenter.js
+++ b/src/components/Hours/Current/expanded_presenter.js
@@ -26,11 +26,11 @@ const Presenter = (hoursEntry, isOpen, collapseHandler, children) => {
         </h4>
       </a>
       <div className='row hours-listing' id={hoursEntry.servicePoint.slug}>
-        <div className='col-md-4'>
+        <div className='col-md-5'>
           <WeeklyHours hours={hoursEntry.thisWeek} title='Current Hours' showEffectiveDates={false} />
           <WeeklyHours hours={hoursEntry.upcomingDifferentHours} title='Upcoming Hours' showEffectiveDates />
         </div>
-        <div className='col-md-6 col-md-offset-2'>
+        <div className='col-md-6 col-md-offset-1'>
           {children}
         </div>
       </div>

--- a/src/components/Hours/Current/index.js
+++ b/src/components/Hours/Current/index.js
@@ -9,8 +9,9 @@ import makeGetHoursForServicePoint from '../../../selectors/hours'
 import * as statuses from '../../../constants/APIStatuses'
 import InlineContainer from '../InlineContainer'
 
-// Parses date/time from the strings given in an hoursEntry.
-const timeToday = (dateString, timeString, utcOffset) => {
+// Parses date/time from the strings given in an hoursEntry. midnightDayOffset specifies an adjustment
+// to the day when the time given is "00:MM". This should generally only be set to +1 for close dates
+const timeToday = (dateString, timeString, utcOffset, midnightDayOffset) => {
   // This does not account for time zone differences
   // We have to split the strings instead of concating as [date]T[time] because different browsers
   //   parse the timezone differently if it's not defined (UTC vs local)
@@ -20,9 +21,14 @@ const timeToday = (dateString, timeString, utcOffset) => {
   const offsetArray = utcOffset.split(':')
   const offsetHrs = parseInt(offsetArray[0])
   const offsetMins = (offsetHrs * 60) + parseInt(offsetArray[1])
-  // Month is month - 1 because date month is 0 based
-  let time = new Date(Number(dateArray[0]), Number(dateArray[1]) - 1, Number(dateArray[2]),
-                          Number(timeArray[0]), Number(timeArray[1]))
+
+  const hour = Number(timeArray[0])
+  const minute = Number(timeArray[1])
+  const year = Number(dateArray[0])
+  const month = Number(dateArray[1]) - 1 // Month is month - 1 because date month is 0 based
+  const day = Number(dateArray[2]) + (hour === 0 ? midnightDayOffset : 0)
+  let time = new Date(year, month, day, hour, minute)
+
   // The difference in offsets between local time and the api's time, in minutes
   let offsetDeltaMins = -offsetMins - time.getTimezoneOffset()
   return new Date(time.getTime() + (offsetDeltaMins * 60000))
@@ -82,8 +88,8 @@ export class CurrentHoursContainer extends Component {
     try {
       const entry = props.hoursEntry
       const currentOpenBlocks = entry.today.hours.filter(hoursBlock => {
-        let opens = timeToday(hoursBlock.date, hoursBlock.opens, props.hoursEntry.utcOffset)
-        let closes = timeToday(hoursBlock.date, hoursBlock.closes, props.hoursEntry.utcOffset)
+        let opens = timeToday(hoursBlock.date, hoursBlock.opens, props.hoursEntry.utcOffset, 0)
+        let closes = timeToday(hoursBlock.date, hoursBlock.closes, props.hoursEntry.utcOffset, 1)
         let now = new Date()
         if (opens <= now && now <= closes) {
           return true


### PR DESCRIPTION
Adds special handling when the close time is at midnight. Also changed spacing of hours. Was causing the text to jumble, making it read incorrect hours when the display text was long, ex: "Wednesday - Thursday"