### PR TITLE
Add a day to some event end times

### DIFF
--- a/src/components/Home/Events/index.js
+++ b/src/components/Home/Events/index.js
@@ -28,10 +28,17 @@ export const mapEvents = (json) => {
   return json.map((entry) => {
     // flatten locales to just 'en-us' and convert strings to datetime type
     flattenLocale(entry.fields, 'en-US')
+
+    let end = entry.fields.endDate ? new Date(entry.fields.endDate) : new Date(entry.fields.startDate)
+    // if end time is 0:00, add a day
+    if (end.getHours() === 0 && end.getMinutes() === 0) {
+      end.setDate(end.getDate() + 1)
+    }
+
     return {
       ...entry.fields,
       startDate: new Date(entry.fields.startDate),
-      endDate: entry.fields.endDate ? new Date(entry.fields.endDate) : new Date(entry.fields.startDate),
+      endDate: end,
     }
   })
   .map((entry) => {

--- a/src/components/Home/Events/index.js
+++ b/src/components/Home/Events/index.js
@@ -30,9 +30,9 @@ export const mapEvents = (json) => {
     flattenLocale(entry.fields, 'en-US')
 
     let end = entry.fields.endDate ? new Date(entry.fields.endDate) : new Date(entry.fields.startDate)
-    // if end time is 0:00, add a day
+    // if end time is 0:00, add 23:59
     if (end.getHours() === 0 && end.getMinutes() === 0) {
-      end.setDate(end.getDate() + 1)
+      end.setTime(end.getTime() + (23 * 60 * 60 * 1000) + (59 * 60 * 1000))
     }
 
     return {


### PR DESCRIPTION
If the event ends at 0:00, assume it actually ends at the end of the day so add 23:59 to make sure it still displays the right day, but will show up until midnight. 