### PR TITLE
Multiple service points on Dynamic Pages (courses)

### DIFF
--- a/deploy/contentfulMigrations/addServicePointsToDynamicPages.js
+++ b/deploy/contentfulMigrations/addServicePointsToDynamicPages.js
@@ -1,0 +1,21 @@
+const forward = (migration) => {
+  const dynamicPage = migration.editContentType('dynamicPage')
+
+  dynamicPage.createField('servicePoints')
+    .name('Service Points')
+    .type('Array')
+    .items({
+      type: 'Link',
+      validations: [{
+        linkContentType: ['servicePoint'],
+      }],
+      linkType: 'Entry',
+    })
+}
+
+const reverse = (migration) => {
+  const dynamicPage = migration.editContentType('dynamicPage')
+  dynamicPage.deleteField('servicePoints')
+}
+
+module.exports = forward

--- a/src/components/Contentful/StaticContent/Sidebar/presenter.js
+++ b/src/components/Contentful/StaticContent/Sidebar/presenter.js
@@ -8,13 +8,16 @@ import Librarians from '../../../Librarians'
 import Related from '../../../Related'
 import ServicePoint from '../../../Contentful/ServicePoint'
 
-
 const Presenter = ({ cfStatic }) => (
   <div key={`ContentfulSidebar_${cfStatic.sys.id}`} className='col-md-4 col-sm-5 col-xs-12 right'>
     <PageLink className='button callout' cfPage={cfStatic.fields.callOutLink} />
     <LibMarkdown>{cfStatic.fields.shortDescription}</LibMarkdown>
     <Librarians netids={cfStatic.fields.contactPeople} />
-    <ServicePoint cfServicePoint={cfStatic.fields.servicePoint } />
+    {
+      cfStatic.fields.servicePoints && cfStatic.fields.servicePoints.map((point, index) => {
+        return <ServicePoint cfServicePoint={point} key={index + '_point'} />
+      })
+    }
     <Related className='p-pages' title='Related Pages' showImages={false}>{ cfStatic.fields.relatedPages }</Related>
   </div>
 )


### PR DESCRIPTION
- allow multiple service points on dynamic pages
- add migration for this contentful change using [this tool](https://github.com/contentful/migration-cli). The migration will be done before deployment, since we currently have no methodology for pre/post deploy scripts. 