### PR TITLE
Event Time Display

### DIFF
--- a/src/components/LandingPages/Events/presenter.js
+++ b/src/components/LandingPages/Events/presenter.js
@@ -14,20 +14,25 @@ export const makeEventEntry = (entry, index, showDescription = true) => {
       key={'events_' + index}
     >
       <Link
-        ariaLabel={entry.title + ' on ' + entry.displayWeekday + ', ' + entry.displayDay + ' ' + entry.displayMonth + ' ' + entry.displayYear}
+        ariaLabel={entry.title + ' on ' + entry.displayDate + ' at ' + entry.displayTime}
         to={'/event/' + entry.slug}
         itemProp='mainEntityOfPage'
       >
-        <time dateTime={entry.startDate} className='date-as-calendar inline-flex'>
-          <meta itemProp='startDate' content={entry.startDate} />
-          <meta itemProp='endDate' content={entry.endDate} />
-          <span className='weekday'>{entry.displayWeekday}</span>
-          <span className='day'>{entry.displayDay}</span>
-          <span className='month'>{entry.displayMonth}</span>
-          <span className='year'>{entry.displayYear}</span>
-        </time>
+        <meta itemProp='startDate' content={entry.startDate} />
+        <meta itemProp='endDate' content={entry.endDate} />
         <div className='event-card-text'>
+
           <h3 itemProp='name'>{entry.title}</h3>
+          <div className='date'>
+            {
+              entry.displayDate
+            }
+          </div>
+          <div className='time'>
+            {
+              entry.displayTime
+            }
+          </div>
         </div>
         { showDescription && (
             <div className='description' itemProp='description'>

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -2005,40 +2005,30 @@ address {
   font-weight: normal;
 }
 
+.news-card a, .event-card a {
+  text-decoration: none;
+}
+
 .event-card {
   clear: left;
   min-height: 120px;
-}
-.event-card .date {
-  float: left;
-  -webkit-box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.25);
-  -moz-box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.25);
-  box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.25);
-  width: 90px;
-  height: 85px;
-  text-align: center;
-  background: #fff;
-  color: #999999;
-  font-family: GPMed, sans-serif;
-  padding: 15px 10px;
-  margin-right: 15px;
-  display: inline-block;
+  padding-bottom: 22px;
 }
 
-.event-card .date em {
+.event-card h3 {
+  margin-bottom: 0;
+}
+
+.event-card .date, .event-card .time {
   font-style: normal;
-  font-size: 18px;
+  font-size: 16px;
   text-transform: uppercase;
-}
-
-.event-card .date strong {
-  font-size: 30px;
-  font-weight: normal;
+  padding: 3px 0px;
 }
 
 .event-card-text {
   display: inline-block;
-  width: calc(100% - 110px)
+  width: auto;
 }
 .description, header {
   overflow: hidden;


### PR DESCRIPTION
- update event time display
  - remove calendar card
  - show both date and time on events
  - fix landing page spacing issues
- make sure neither events or news are underlined