### PR TITLE
Search Partner Libraries

### DIFF
--- a/src/components/SearchDrawer/PartnerSearchToggle/index.js
+++ b/src/components/SearchDrawer/PartnerSearchToggle/index.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import Presenter from './presenter'
+import { setSearchOption } from '../../../actions/advancedSearch'
+
+const mapStateToProps = (state, ownProps) => {
+  return {
+    ...state,
+  }
+}
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    onChange: (e) => {
+      dispatch(setSearchOption(e.target.id, e.target.checked))
+    },
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Presenter)

--- a/src/components/SearchDrawer/PartnerSearchToggle/presenter.js
+++ b/src/components/SearchDrawer/PartnerSearchToggle/presenter.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import searchOptions, { NDCATALOG } from '../searchOptions'
+
+const PartnerSearchToggle = (props) => {
+  if (props.currentSearch.uid === NDCATALOG) {
+    return (<span className='searchPartners'>Search Partner Libraries<input
+      type='checkbox'
+      id='searchPartners'
+      onChange={props.onChange}
+    /></span>)
+  }
+  return null
+}
+
+PartnerSearchToggle.propTypes = {
+  currentSearch: PropTypes.object.isRequired,
+}
+
+export default PartnerSearchToggle

--- a/src/components/SearchDrawer/presenter.js
+++ b/src/components/SearchDrawer/presenter.js
@@ -5,6 +5,7 @@ import SearchPreference from './SearchPreference'
 import SearchBox from './SearchBox'
 import AdvancedSearch from './AdvancedSearch'
 import AdditionalLinks from './AdditionalLinks'
+import PartnerSearchToggle from './PartnerSearchToggle'
 import '../../static/css/global.css'
 import '../../static/css/search.css'
 
@@ -25,6 +26,7 @@ const Drawer = (props) => {
             currentSearch={props.currentSearch}
           />
           <AdditionalLinks {...props} />
+          <PartnerSearchToggle currentSearch={props.currentSearch} />
         </form>
       </div>
     </section>

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -1202,6 +1202,14 @@ label[for='q']:after, .uSearchBox label:after {
   float: right;
 }
 
+.appliance .searchPartners {
+  font-size: 14px;
+  color: #fff;
+  float: right;
+  margin-top: 1.5em;
+  padding-top: 3px;
+  padding-right: 1.5em;
+}
 
 .set-default-search, .additional-links, .has-default-search {
   font-size: 14px !important;
@@ -2868,7 +2876,7 @@ body {
   .hservices {
     grid-template-columns: 1fr;
   }
-  .appliance .additional-links, #save-preference {
+  .appliance .additional-links, .appliance .searchPartners, #save-preference {
     display: none;
   }
 


### PR DESCRIPTION
Add a Search Partner Libraries toggle for ND Catalog. 

I changed the URLs used for onsearch/ndcatalog search. I couldn't find a difference between the`search.do` and `dlsearch.do` urls. The documentation is very sparse, but it seems like they're used interchangeably.  Mostly I went off what actually happens when you go to onesearch, it's always `search.do` so that simplified the query generation code a bit. I did test this, it seems to work the same as on prod, so no change to users should be visible. Changing the scopes requires the `search.do` url, so it made sense to change everything to conform to one.