### PR TITLE
LW-143:  Rearrange order of items on pathfinder pages

### DIFF
--- a/src/components/Contentful/ContactPoint/index.js
+++ b/src/components/Contentful/ContactPoint/index.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Image from '../../Image'
+import PageLink from '../PageLink'
+import Librarians from '../../Librarians'
+import ServicePoint from '../ServicePoint'
+import Related from '../../Related'
+
+const ContactPoint = ({ cfPageEntry, mobile }) => (
+  <section className={mobile ? 'mobile-only' : 'col-md-4 col-sm-5 col-xs-12 right desktop-only'}>
+    {mobile ? null : <Image cfImage={cfPageEntry.fields.image} className='cover' />}
+    <PageLink className='button callout' cfPage={cfPageEntry.fields.callOutLink} />
+    <Librarians netids={cfPageEntry.fields.contactPeople} />
+    {
+      cfPageEntry.fields.servicePoints && cfPageEntry.fields.servicePoints.map((point, index) => {
+        return <ServicePoint cfServicePoint={point} key={index + '_point'} />
+      })
+    }
+    <Related
+      className='p-pages'
+      title='Related Pages'
+      showImages={false}
+    >
+      { cfPageEntry.fields.relatedPages }
+    </Related>
+  </section>
+)
+
+ContactPoint.propTypes = {
+  cfPageEntry: PropTypes.object.isRequired,
+  mobile: PropTypes.bool,
+}
+
+export default ContactPoint

--- a/src/components/Contentful/Page/presenter.js
+++ b/src/components/Contentful/Page/presenter.js
@@ -4,14 +4,11 @@ import PropTypes from 'prop-types'
 import '../../../static/css/global.css'
 import LibMarkdown from '../../LibMarkdown'
 import Related from '../../Related'
-import Image from '../../Image'
-import Librarians from '../../Librarians'
 import PageTitle from '../../PageTitle'
 import SearchProgramaticSet from '../../SearchProgramaticSet'
-import PageLink from '../PageLink'
 import ServicePoint from '../ServicePoint'
 import PageAlert from '../Alert/Page'
-
+import ContactPoint from '../ContactPoint/'
 const PagePresenter = ({ cfPageEntry }) => (
   <div className='container-fluid content-area'>
     <PageTitle title={cfPageEntry.fields.title} />
@@ -22,10 +19,12 @@ const PagePresenter = ({ cfPageEntry }) => (
         <PageAlert alert={cfPageEntry.fields.alert} />
         <div className='sp-hidden'><ServicePoint cfServicePoint={cfPageEntry.fields.servicePoint} /></div>
         <LibMarkdown>{ cfPageEntry.fields.body }</LibMarkdown>
-
+        <div className='mobile-only'>
+          <ContactPoint cfPageEntry={cfPageEntry} mobile />
+        </div>
         <Related
           className='p-resources'
-          title={ cfPageEntry.fields.relatedResourcesTitleOverride ? cfPageEntry.fields.relatedResourcesTitleOverride : 'Resources' }
+          title={cfPageEntry.fields.relatedResourcesTitleOverride ? cfPageEntry.fields.relatedResourcesTitleOverride : 'Resources'}
           showImages={false}
         >
           { cfPageEntry.fields.relatedResources }
@@ -61,23 +60,8 @@ const PagePresenter = ({ cfPageEntry }) => (
           })
         }
       </section>
-      <section className='col-md-4 col-sm-5 col-xs-12 right'>
-        <Image cfImage={cfPageEntry.fields.image} className='cover' />
-        <PageLink className='button callout' cfPage={cfPageEntry.fields.callOutLink} />
-        <Librarians netids={cfPageEntry.fields.contactPeople} />
-        {
-          cfPageEntry.fields.servicePoints && cfPageEntry.fields.servicePoints.map((point, index) => {
-            return <ServicePoint cfServicePoint={point} key={index + '_point'} />
-          })
-        }
-        <Related
-          className='p-pages'
-          title='Related Pages'
-          showImages={false}
-        >
-          { cfPageEntry.fields.relatedPages }
-        </Related>
-      </section>
+      <ContactPoint cfPageEntry={cfPageEntry} mobile={false} />
+
     </div>
   </div>
 )

--- a/src/components/Contentful/Page/style.css
+++ b/src/components/Contentful/Page/style.css
@@ -153,9 +153,21 @@ a.side-anchors::before {
   margin-left: -15px;
 }
 
+.mobile-only {
+  display: none;
+}
+.desktop-only {
+  display: block;
+}
 @media screen and (max-width: 780px) {
 	.linksgroup {
 		-moz-column-count: 1;
 		column-count: 1;
 	}
+  .mobile-only {
+    display: block;
+  }
+  .desktop-only {
+    display: none;
+  }
 }

--- a/src/tests/components/Contentful/ContactPoint/index.test.js
+++ b/src/tests/components/Contentful/ContactPoint/index.test.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ContactPoint from '../../../../components/Contentful/ContactPoint'
+import Image from '../../../../components/Image'
+
+const setup = (cfPageEntry) => {
+  return shallow(<ContactPoint cfPageEntry={cfPageEntry} />)
+}
+
+let enzymeWrapper
+describe('components/Contentful/ContactPoint/index', () => {
+  beforeEach(() => {
+    enzymeWrapper = setup({
+      fields: {
+        image: 'Fake image',
+      },
+    })
+  })
+
+  afterEach(() => {
+    enzymeWrapper = undefined
+  })
+
+  it('should render Image for image', () => {
+    expect(enzymeWrapper.containsMatchingElement(<Image cfImage={'Fake image'} />)).toBe(true)
+  })
+})

--- a/src/tests/components/Contentful/Page/presenter.test.js
+++ b/src/tests/components/Contentful/Page/presenter.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import PagePresenter from '../../../../components/Contentful/Page/presenter'
-import Image from '../../../../components/Image'
+import ContactPoint from '../../../../components/Contentful/ContactPoint'
 
 const setup = (cfPageEntry) => {
   return shallow(<PagePresenter cfPageEntry={cfPageEntry} />)
@@ -39,10 +39,6 @@ describe('components/Contentful/Page/presenter', () => {
     expect(enzymeWrapper.find('LibMarkdown').children().node).toBe('Fake content')
   })
 
-  it('should render Image for image', () => {
-    expect(enzymeWrapper.containsMatchingElement(<Image cfImage={'Fake image'} />)).toBe(true)
-  })
-
   it('should render Related for related resources', () => {
     expect(enzymeWrapper.find('Related').someWhere(n => n.children().node === 'Fake related resources')).toBe(true)
   })
@@ -53,5 +49,9 @@ describe('components/Contentful/Page/presenter', () => {
 
   it('should render Related for libguides', () => {
     expect(enzymeWrapper.find('Related').someWhere(n => n.children().node === 'Fake related libguides')).toBe(true)
+  })
+
+  it('should render ContactPoint twice', () => {
+    expect(enzymeWrapper.find('ContactPoint').length).toBe(2)
   })
 })


### PR DESCRIPTION
MOBILE - Rearrange order of items on pathfinder pages on mobile -
hours/location/contact info should be at top, and related pages should
be at the bottom

* Move Contact/Service content to sub component
* Include component in two different places and include a mobile flag
to determine where it should be displayed.