### PR TITLE
Don't use timezone info for events

### DIFF
--- a/src/components/Home/Events/index.js
+++ b/src/components/Home/Events/index.js
@@ -26,10 +26,11 @@ const makeLocalTimezone = (stringDate) => {
   stringDate = stringDate.replace(givenTz, stringLocalTz)
 
   let ret = new Date(stringDate)
-  // if the given date doesn't have the same tz, we need to offset to negate the Date functionality
-  if (givenTz !== stringLocalTz) {
+  let retOffset = ret.getTimezoneOffset()
+  // if the changed date is in a different timezone than us (daylight savings) offset it back
+  if (retOffset !== localOffset) {
     // in minutes
-    let offset = localOffset - ret.getTimezoneOffset()
+    let offset = localOffset - retOffset
     // to milliseconds
     offset = offset * 60 * 1000
 


### PR DESCRIPTION
We don't want to use the timezone information from contentful anymore. 

To do this, we must force the strings to be our local timezone BEFORE passing them to a Date object. If, after we force our timezone, they are still in a different timezone (the Date class converted it because it was in a different daylight savings time state than we currently are) we must offset it back to our local time.