### PR TITLE
Fix the page title

### DIFF
--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -17,7 +17,7 @@ class Home extends Component {
   render () {
     return (
       <div className='Home main'>
-        <PageTitle title='Hesburgh Library' hideInPage />
+        <PageTitle title='Hesburgh Libraries' hideInPage />
         <SearchProgramaticSet open />
         <HomePageHours />
 

--- a/src/components/PageTitle/index.js
+++ b/src/components/PageTitle/index.js
@@ -5,9 +5,13 @@ import PropTypes from 'prop-types'
 class PageTitle extends Component {
   componentWillMount () {
     if (this.props.title) {
-      document.title = this.props.title + ' | Hesburgh Library'
+      if (this.props.title === 'Hesburgh Libraries') {
+        document.title = this.props.title
+      } else {
+        document.title = this.props.title + ' | Hesburgh Libraries'
+      }
     } else {
-      document.title = 'Hesburgh Library'
+      document.title = 'Hesburgh Libraries'
     }
   }
 


### PR DESCRIPTION
The page title on the homepage is currently 

Hesburgh Library | Hesburgh Library

It should be 
Hesburgh Libraries
and subpages should be 

New Page | Hesburgh Libraries 