### PR TITLE
Changed ARIA role to ID

### DIFF
--- a/src/components/Footer/FooterInfo/index.js
+++ b/src/components/Footer/FooterInfo/index.js
@@ -11,7 +11,11 @@ const FooterInfo = () => {
         <div className='row'>
           <div className='col-xs-12 col-md-4'>
             <div className='box'>
-              <p role='copyright'><Link to='https://www.nd.edu/copyright/'>Copyright</Link> © 2017 University of Notre Dame</p>
+              <p id='copyright' property='dc:rights'>
+                <Link to='https://www.nd.edu/copyright/'>Copyright</Link>&nbsp;
+                <span property='dc:dateCopyrighted'>© 2017</span>&nbsp;
+                <span property='dc:publisher'>University of Notre Dame</span>
+              </p>
               <p><Link to='https://www.google.com/maps/place/Theodore+M.+Hesburgh+Library/@41.7023619,-86.2363832,17z/data=!3m1!4b1!4m5!3m4!1s0x8816d29f1af60a29:0x87f74f541c574744!8m2!3d41.7023579!4d-86.2341945'>221 Hesburgh Library, Notre Dame, IN 46556 </Link></p>
               <p>Phone <a href='tel:5746316679'>(574) 631-6679</a></p>
             </div>


### PR DESCRIPTION
Stops validation error for ARIA roles if we change 'role' in front of copyright to 'id'.

@jonhartzler 