### PR TITLE
Update query generator.

### DIFF
--- a/src/components/SearchDrawer/searchQueryBuilder.js
+++ b/src/components/SearchDrawer/searchQueryBuilder.js
@@ -1,8 +1,13 @@
 import { ONESEARCH, NDCATALOG, CURATEND, LIBRARY } from './searchOptions'
 const onesearchUrl = (queryTerm, isAdvanced, isOnesearch) => {
-  const mode = isAdvanced ? 'Advanced' : 'Basic'
   const tab = isOnesearch ? 'onesearch' : 'nd_campus'
-  return `http://onesearch.library.nd.edu/primo_library/libweb/action/search.do?fn=search&ct=search&initialSearch=true&mode=${mode}&tab=${tab}&indx=1&dum=true&srt=rank&vid=NDU&frbg=&tb=t${queryTerm}`
+
+  if (isAdvanced) {
+    return `http://onesearch.library.nd.edu/primo_library/libweb/action/search.do?fn=search&ct=search&initialSearch=true&mode=Advanced&tab=${tab}&indx=1&dum=true&srt=rank&vid=NDU&frbg=&tb=t${queryTerm}`
+  } else {
+    return `http://onesearch.library.nd.edu/primo_library/libweb/action/dlSearch.do?bulkSize=10&dym=true&highlight=true&indx=1&institution=NDU&mode=Basic&onCampus=false&pcAvailabiltyMode=true&query=any%2Ccontains%2C${queryTerm}&search_scope=malc_blended&tab=${tab}&vid=NDU&displayField=title&displayField=creator`
+  }
+
 }
 const curateBasicURL = (queryTerm) => {
   return `https://curate.nd.edu/catalog?utf8=%E2%9C%93&amp;search_field=all_fields&amp;q=${queryTerm}`
@@ -94,7 +99,6 @@ const searchQuery = (searchStore, advancedSearch, history) => {
   } else {
     // Basic Search
     searchTerm = advancedSearch['basic-search-field'] || ''
-    searchTerm = '&vl%28freeText0%29=' + searchTerm + '&scp.scps=' + (advancedSearch['searchPartners'] ? partnerScopes : defaultScopes)
   }
 
   switch (searchStore.searchType) {

--- a/src/components/SearchDrawer/searchQueryBuilder.js
+++ b/src/components/SearchDrawer/searchQueryBuilder.js
@@ -45,7 +45,6 @@ const searchQuery = (searchStore, advancedSearch, history) => {
     const drEndDay = advancedSearch['drEndDay'] || '31'
     const drEndMonth = advancedSearch['drEndMonth'] || '12'
     let drEndYear = advancedSearch['drEndYear5']
-    debugger
     // Hack to fix weird date insertion on Primo's end of stuff.
     if (drStartYear || drEndYear) {
       if (!freeText1) {

--- a/src/components/SearchDrawer/searchQueryBuilder.js
+++ b/src/components/SearchDrawer/searchQueryBuilder.js
@@ -1,11 +1,12 @@
 import { ONESEARCH, NDCATALOG, CURATEND, LIBRARY } from './searchOptions'
 const onesearchUrl = (queryTerm, isAdvanced, isOnesearch) => {
   const tab = isOnesearch ? 'onesearch' : 'nd_campus'
+  const seachScope = isOnesearch ? 'malc_blended' : 'nd_campus'
 
   if (isAdvanced) {
-    return `http://onesearch.library.nd.edu/primo_library/libweb/action/search.do?fn=search&ct=search&initialSearch=true&mode=Advanced&tab=${tab}&indx=1&dum=true&srt=rank&vid=NDU&frbg=&tb=t${queryTerm}`
+    return `http://onesearch.library.nd.edu/primo_library/libweb/action/search.do?fn=search&ct=search&initialSearch=true&mode=Advanced&tab=${tab}&indx=1&dum=true&srt=rank&vid=NDU&frbg=&tb=t${queryTerm}&search_scope=${seachScope}`
   } else {
-    return `http://onesearch.library.nd.edu/primo_library/libweb/action/dlSearch.do?bulkSize=10&dym=true&highlight=true&indx=1&institution=NDU&mode=Basic&onCampus=false&pcAvailabiltyMode=true&${queryTerm}&tab=${tab}&vid=NDU&displayField=title&displayField=creator`
+    return `http://onesearch.library.nd.edu/primo_library/libweb/action/dlSearch.do?bulkSize=10&dym=true&highlight=true&indx=1&institution=NDU&mode=Basic&onCampus=false&pcAvailabiltyMode=true&${queryTerm}&search_scope=${seachScope}&tab=${tab}&vid=NDU&displayField=title&displayField=creator`
   }
 
 }
@@ -20,9 +21,6 @@ const libSearchBasicURL = (queryTerm) => {
 const searchQuery = (searchStore, advancedSearch, history) => {
   let searchTerm
   let isAdvanced = searchStore.advancedSearch
-
-  const oneSearchScope = 'malc_blended'
-  const ndCatalogScope = 'nd_campus'
 
   if (isAdvanced) {
     // Advanced Search
@@ -89,22 +87,12 @@ const searchQuery = (searchStore, advancedSearch, history) => {
                 `&vl%28drEndYear5%29=${drEndYear}`
     }
 
-    if (searchStore.searchType === NDCATALOG) {
-      searchTerm += `&search_scope=${ndCatalogScope}`
-    } else {
-      searchTerm += `&search_scope=${oneSearchScope}`
-    }
     searchTerm += `&Submit=Search`
   } else if (searchStore.searchType === LIBRARY || searchStore.searchType === CURATEND) {
     searchTerm = advancedSearch['basic-search-field'] || ''
   } else {
     // Basic Search
     searchTerm = `query=any%2Ccontains%2C${advancedSearch['basic-search-field']}`
-    if (searchStore.searchType === NDCATALOG) {
-      searchTerm += `&search_scope=${ndCatalogScope}`
-    } else {
-      searchTerm += `&search_scope=${oneSearchScope}`
-    }
 
   switch (searchStore.searchType) {
     case ONESEARCH:

--- a/src/components/SearchDrawer/searchQueryBuilder.js
+++ b/src/components/SearchDrawer/searchQueryBuilder.js
@@ -94,23 +94,24 @@ const searchQuery = (searchStore, advancedSearch, history) => {
     // Basic Search
     searchTerm = `query=any%2Ccontains%2C${advancedSearch['basic-search-field']}`
 
-  switch (searchStore.searchType) {
-    case ONESEARCH:
-      window.location = onesearchUrl(searchTerm, isAdvanced, true)
-      break
-    case NDCATALOG:
-      window.location = onesearchUrl(searchTerm, isAdvanced, false)
-      break
-    case CURATEND:
-      window.location = curateBasicURL(searchTerm)
-      break
-    case LIBRARY:
-      window.location = `https://search.nd.edu/search/?client=lib_site_srch&site=library;q=${searchTerm}`
-      // switch to this when search is implemented locally
-      // history.push(libSearchBasicURL(searchTerm))
-      break
-    default:
-      break
+    switch (searchStore.searchType) {
+      case ONESEARCH:
+        window.location = onesearchUrl(searchTerm, isAdvanced, true)
+        break
+      case NDCATALOG:
+        window.location = onesearchUrl(searchTerm, isAdvanced, false)
+        break
+      case CURATEND:
+        window.location = curateBasicURL(searchTerm)
+        break
+      case LIBRARY:
+        window.location = `https://search.nd.edu/search/?client=lib_site_srch&site=library;q=${searchTerm}`
+        // switch to this when search is implemented locally
+        // history.push(libSearchBasicURL(searchTerm))
+        break
+      default:
+        break
+    }
   }
 }
 


### PR DESCRIPTION
The current search box needs to send the basic query to the Deep Link Search file. 

I have changed the box to accommodate this. 

I also updated how we are sending the scope for nd catalog and one search to be the grouped scopes instead of the individual "leaf scopes"  

Unfortunately, we can't send advanced searches to the dlSearch file so we have to have a pretty large branch between the dlSearch.do and the search.do.  

The deep link syntax is necessary because doing a regular search can have too great of a performance affect one primo. Also, the new UI should fix this so we don't have to use the deep link syntax.

IN ADDITION,  in the past we have used factotum to proxy deel link queries.  I am not using that.  I do not think that is an appropriate place to do that anymore.  We may wish to set up an api gateway/lambda to do this.  

