### PR TITLE
Database Info Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## [v2017.10](https://github.com/ndlib/usurper/tree/v2017.10)
-[Full Changelog](https://github.com/ndlib/usurper/compare/v2017.9...v2017.10)
+## [v2018.1](https://github.com/ndlib/usurper/tree/v2018.1)
+[Full Changelog](https://github.com/ndlib/usurper/compare/v2017.9...v2018.1)
 
 ### New features/enhancements
 - Limit the lines of displayed database description [#356](https://github.com/ndlib/usurper/pull/356)

--- a/src/components/Contentful/Database/presenter.js
+++ b/src/components/Contentful/Database/presenter.js
@@ -21,17 +21,28 @@ const DatabasePresenter = ({ cfDatabaseEntry, fieldData }) => (
           <h2>Database Access</h2>
           <ul className='databaseLink'>
             {
-              cfDatabaseEntry.fields.urls.map((data) => {
-                let linkText = cfDatabaseEntry.fields.urls.length > 1 ? data.title : cfDatabaseEntry.fields.title
-                return (
-                  <li key={data.url}>
-                    <Link to={data.url}>{ linkText }</Link>
-                    {
-                      data.notes && <LibMarkdown>{ data.notes }</LibMarkdown>
-                    }
-                  </li>
-                )
-              })
+              // only use this if the field exists
+              cfDatabaseEntry.fields.urls && (
+                cfDatabaseEntry.fields.urls.map((data) => {
+                  let linkText = cfDatabaseEntry.fields.urls.length > 1 ? data.title : cfDatabaseEntry.fields.title
+                  return (
+                    <li key={data.url}>
+                      <Link to={data.url}>{ linkText }</Link>
+                      {
+                        data.notes && <LibMarkdown>{ data.notes }</LibMarkdown>
+                      }
+                    </li>
+                  )
+                })
+              )
+            }
+            {
+              // if that doesn't exist, use legacy information
+              !cfDatabaseEntry.fields.urls && (
+                <li key={cfDatabaseEntry.fields.purl}>
+                  <Link to={cfDatabaseEntry.fields.purl}>{ cfDatabaseEntry.fields.title }</Link>
+                </li>
+              )
             }
           </ul>
         </section>


### PR DESCRIPTION
Make sure the database pages still work before the new information is added.

Once the new sync is running we can remove this and only use the new version, but to support the change we need both.