### PR TITLE
Fix infinite requests on non-existant secure pages

### DIFF
--- a/src/actions/contentful/page.js
+++ b/src/actions/contentful/page.js
@@ -16,6 +16,7 @@ const receiveError = (page, response) => {
     type: CF_RECEIVE_PAGE,
     status: statuses.fromHttpStatusCode(response.errorStatus),
     error: response,
+    slug: page,
     receivedAt: Date.now(),
   }
 }


### PR DESCRIPTION
The secure page container checks to see if the current slug matches the expected slug and if it doesn't, fetch the page. This makes sense to make sure we're grabbing new page content when coming from another page - but since the error action doesn't have a slug it will never match the expected (either be previous page or null). Thus, infinite loop of requests.