### PR TITLE
Add alerts to dynamic pages

### DIFF
--- a/deploy/ci/buckets.yml
+++ b/deploy/ci/buckets.yml
@@ -5,9 +5,6 @@ Outputs:
   ArtifactBucket:
     Description: The artifact bucket for the build CI
     Value: !Ref ArtifactBucket
-  OutBucket:
-    Description: The out bucket for the build CI
-    Value: !Ref OutBucket
 
 Parameters:
   ServiceName:
@@ -19,30 +16,11 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub ${ServiceName}-artifacts
+      LifecycleConfiguration:
+        Rules:
+          - Id: SweepRule
+            ExpirationInDays: 15
+            Status: Enabled
       Tags:
         - Key: Name
           Value: !Sub ${ServiceName}-artifacts
-
-  OutBucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Sub ${ServiceName}-built
-      AccessControl: PublicRead
-      WebsiteConfiguration:
-        IndexDocument: index.html
-      Tags:
-        - Key: Name
-          Value: !Sub ${ServiceName}-built
-
-  WebPolicy:
-    Type: AWS::S3::BucketPolicy
-    DependsOn: OutBucket
-    Properties:
-      Bucket: !Ref OutBucket
-      PolicyDocument:
-        Version: "2008-10-17"
-        Statement:
-          - Effect: "Allow"
-            Principal: "*"
-            Action: "s3:GetObject"
-            Resource: !Sub "arn:aws:s3:::${OutBucket}/*"

--- a/deploy/ci/config.yml
+++ b/deploy/ci/config.yml
@@ -6,14 +6,15 @@ Stacks:
       Template: root.yml
       Parameters:
         Repo: usurper
-        Branch: master
+        Branch: ua
         OAuth: ${OAUTH}
         ServiceName: $SERVICE-$STAGE
         TemplateLoc: https://s3.amazonaws.com/$DEPLOY_BUCKET/$DEPLOY_FOLDER
+        OutBucket: dev-staging.library.nd.edu
       Tags:
         Name: $SERVICE-$STAGE
-        Owner: ${USER}
-        Contact: ${USER}@nd.edu
+        Owner: WSE
+        Contact: WSE
         Description: CI for the Usurper Project
         InceptDate: $TIMESTAMP
 

--- a/deploy/ci/config.yml
+++ b/deploy/ci/config.yml
@@ -11,6 +11,8 @@ Stacks:
         ServiceName: $SERVICE-$STAGE
         TemplateLoc: https://s3.amazonaws.com/$DEPLOY_BUCKET/$DEPLOY_FOLDER
         OutBucket: dev-staging.library.nd.edu
+        HoursApiUrl: https://677xoyg276.execute-api.us-east-1.amazonaws.com/prep
+        ContentfulApi: https://77qwzi0dp1.execute-api.us-east-1.amazonaws.com/prep
       Tags:
         Name: $SERVICE-$STAGE
         Owner: WSE

--- a/deploy/ci/resources.yml
+++ b/deploy/ci/resources.yml
@@ -20,6 +20,10 @@ Parameters:
   OutBucket:
     Type: String
     Description: Name of the output bucket
+  HoursApiUrl:
+    Type: String
+  ContentfulApi:
+    Type: String
   ArtifactBucket:
     Type: String
     Description: Name of the artifact bucket
@@ -40,6 +44,10 @@ Resources:
         EnvironmentVariables:
         - Name: REACT_OUTPUT
           Value: !Ref OutBucket
+        - Name: HOURS_API_URL
+          Value: !Ref HoursApiUrl
+        - Name: CONTENTFUL_API
+          Value: !Ref ContentfulApi
       Source:
         Type: CODEPIPELINE
       TimeoutInMinutes: 10

--- a/deploy/ci/root.yml
+++ b/deploy/ci/root.yml
@@ -14,6 +14,9 @@ Parameters:
   TemplateLoc:
     Type: String
     Description: The bucket url where these templates are stored
+  OutBucket:
+    Type: String
+    Description: Name of the bucket to put the built website into
 
 Resources:
   BucketsStack:
@@ -30,7 +33,7 @@ Resources:
       TemplateURL: !Sub ${TemplateLoc}/roles.yml
       Parameters:
         ServiceName: !Ref ServiceName
-        OutBucket: !GetAtt BucketsStack.Outputs.OutBucket
+        OutBucket: !Ref OutBucket
         ArtifactBucket: !GetAtt BucketsStack.Outputs.ArtifactBucket
 
   ResourcesStack:
@@ -39,7 +42,7 @@ Resources:
     Properties:
       TemplateURL: !Sub ${TemplateLoc}/resources.yml
       Parameters:
-        OutBucket: !GetAtt BucketsStack.Outputs.OutBucket
+        OutBucket: !Ref OutBucket
         ArtifactBucket: !GetAtt BucketsStack.Outputs.ArtifactBucket
         RoleArn: !GetAtt RolesStack.Outputs.RoleArn
         ServiceName: !Ref ServiceName

--- a/deploy/ci/root.yml
+++ b/deploy/ci/root.yml
@@ -17,6 +17,10 @@ Parameters:
   OutBucket:
     Type: String
     Description: Name of the bucket to put the built website into
+  HoursApiUrl:
+    Type: String
+  ContentfulApi:
+    Type: String
 
 Resources:
   BucketsStack:
@@ -49,3 +53,5 @@ Resources:
         Repo: !Ref Repo
         Branch: !Ref Branch
         OAuth: !Ref OAuth
+        HoursApiUrl: !Ref HoursApiUrl
+        ContentfulApi: !Ref ContentfulApi

--- a/deploy/contentfulMigrations/2018.01.29.addDynamicPageAlerts.js
+++ b/deploy/contentfulMigrations/2018.01.29.addDynamicPageAlerts.js
@@ -1,0 +1,17 @@
+const forward = (migration) => {
+  const dynamicPage = migration.editContentType('dynamicPage')
+
+  dynamicPage.createField('alert')
+    .name('Alert')
+    .type('Link')
+    .linkType('Entry')
+    .validations([
+      { linkContentType: [ 'alert' ] },
+    ])
+}
+
+const reverse = (migration) => {
+  migration.editContentType('dynamicPage').deleteField('alert')
+}
+
+module.exports = forward

--- a/deploy/contentfulMigrations/2018.01.29.addDynamicPageAlerts.js
+++ b/deploy/contentfulMigrations/2018.01.29.addDynamicPageAlerts.js
@@ -8,10 +8,21 @@ const forward = (migration) => {
     .validations([
       { linkContentType: [ 'alert' ] },
     ])
+
+  const container = migration.editContentType('columnContainer')
+
+  container.createField('alert')
+    .name('Alert')
+    .type('Link')
+    .linkType('Entry')
+    .validations([
+      { linkContentType: [ 'alert' ] },
+    ])
 }
 
 const reverse = (migration) => {
   migration.editContentType('dynamicPage').deleteField('alert')
+  migration.editContentType('columnContainer').deleteField('alert')
 }
 
 module.exports = forward

--- a/src/components/Contentful/Alert/Page/index.js
+++ b/src/components/Contentful/Alert/Page/index.js
@@ -20,6 +20,8 @@ const mapStateToProps = (state, ownProps) => {
     alerts.sort(alertSort)
 
     alerts = alertCatagorize(alerts)
+  } else {
+    alerts = {}
   }
   return {
     alerts: alerts,
@@ -33,7 +35,7 @@ class AlertContainer extends Component {
 }
 
 AlertContainer.propTypes = {
-  alerts: PropTypes.array,
+  alerts: PropTypes.object,
 }
 
 export default connect(mapStateToProps)(AlertContainer)

--- a/src/components/Contentful/Alert/Page/index.js
+++ b/src/components/Contentful/Alert/Page/index.js
@@ -33,7 +33,7 @@ class AlertContainer extends Component {
 }
 
 AlertContainer.propTypes = {
-  alerts: PropTypes.object,
+  alerts: PropTypes.array,
 }
 
 export default connect(mapStateToProps)(AlertContainer)

--- a/src/components/Contentful/Page/columnPresenter.js
+++ b/src/components/Contentful/Page/columnPresenter.js
@@ -5,6 +5,7 @@ import PageTitle from '../../PageTitle'
 import Link from '../../Link'
 import LibMarkdown from '../../LibMarkdown'
 import SideNav from '../../SideNav'
+import PageAlert from '../Alert/Page'
 
 import './style.css'
 
@@ -43,6 +44,7 @@ const ColumnContainerPresenter = (props) => {
     <div className='content'>
       <SearchProgramaticSet open={false} />
       <PageTitle title={page.title} />
+      <PageAlert alert={page.alert} />
       <div className='row landing'>
         {
           page.columns.map((column, index) => {

--- a/src/components/Contentful/StaticContent/Alert/index.js
+++ b/src/components/Contentful/StaticContent/Alert/index.js
@@ -1,0 +1,47 @@
+// Container component for a Floor content type from Contentful
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import { fetchSidebar } from '../../../../actions/contentful/staticContent'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import PresenterFactory from '../../../APIInlinePresenterFactory'
+import Presenter from './presenter.js'
+
+const mapStateToProps = (state) => {
+  return { cfStatic: state.cfStatic }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ fetchSidebar }, dispatch)
+}
+
+export class AlertContainer extends Component {
+  componentDidMount () {
+    this.props.fetchSidebar(this.props.slug, this.props.preview)
+  }
+
+  render () {
+    if (this.props.cfStatic.slug !== this.props.slug) {
+      return null
+    }
+
+    return <PresenterFactory
+      presenter={Presenter}
+      status={this.props.cfStatic.status}
+      props={{ cfStatic: this.props.cfStatic.json }} />
+  }
+}
+
+AlertContainer.propTypes = {
+  fetchSidebar: PropTypes.func.isRequired,
+  cfStatic: PropTypes.object.isRequired,
+  preview: PropTypes.bool.isRequired,
+  slug: PropTypes.string.isRequired,
+}
+
+const Sidebar = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(AlertContainer)
+
+export default Sidebar

--- a/src/components/Contentful/StaticContent/Alert/presenter.js
+++ b/src/components/Contentful/StaticContent/Alert/presenter.js
@@ -1,0 +1,15 @@
+// Presenter component for a Floor content type from Contentful
+import React from 'react'
+import PropTypes from 'prop-types'
+import '../../../../static/css/global.css'
+import PageAlert from '../../Alert/Page'
+
+const Presenter = ({ cfStatic }) => (
+  <PageAlert alert={cfStatic.fields.alert} />
+)
+
+Presenter.propTypes = {
+  cfStatic: PropTypes.object.isRequired,
+}
+
+export default Presenter

--- a/src/components/Courses/presenter.js
+++ b/src/components/Courses/presenter.js
@@ -9,6 +9,7 @@ import Lgicon from '../../static/images/icons/libguide.png'
 import LogOut from '../LogOut'
 import StaticSidebar from '../Contentful/StaticContent/Sidebar'
 import StaticBody from '../Contentful/StaticContent/Body'
+import StaticAlert from '../Contentful/StaticContent/Alert'
 
 class Courses extends Component {
   instructorCard (course) {
@@ -162,7 +163,7 @@ class Courses extends Component {
         <div key='courses' className='content'>
           <LogOut />
           <Link to='/items-requests' className='button fright tab'>My Items</Link>
-          
+
           <PageTitle title='Courses' classaName='hr-cor' />
           <SearchProgramaticSet open={false} />
 
@@ -170,6 +171,7 @@ class Courses extends Component {
 
           <div className='row'>
             <div className='col-md-8 col-sm-7'>
+              <StaticAlert slug='courses' preview={this.props.preview} />
               <div key='courseCards'>
                 { this.courseCards() }
               </div>

--- a/src/components/Hours/Page/presenter.js
+++ b/src/components/Hours/Page/presenter.js
@@ -7,6 +7,7 @@ import SearchProgramaticSet from '../../SearchProgramaticSet'
 import PageTitle from '../../PageTitle'
 import StaticSidebar from '../../Contentful/StaticContent/Sidebar'
 import StaticBody from '../../Contentful/StaticContent/Body'
+import StaticAlert from '../../Contentful/StaticContent/Alert'
 import Link from '../../Link'
 
 const Presenter = (props) => {
@@ -17,6 +18,8 @@ const Presenter = (props) => {
 
       <div className='row'>
         <div className='col-md-8 col-sm-7'>
+          <StaticAlert slug='hours' preview={props.preview} />
+
           <main className='service-point-list'>
             {
               props.hoursPageOrder.map((servicePointOrder) => {

--- a/src/components/PersonalInfo/presenter.js
+++ b/src/components/PersonalInfo/presenter.js
@@ -10,17 +10,19 @@ import SearchProgramaticSet from '../SearchProgramaticSet'
 import LogOut from '../LogOut'
 import StaticSidebar from '../Contentful/StaticContent/Sidebar'
 import StaticBody from '../Contentful/StaticContent/Body'
+import StaticAlert from '../Contentful/StaticContent/Alert'
 
 const LoggedIn = (preview) => {
   return (
     <div className='content'>
       <LogOut />
       <Courses linkOnly />
-      
+
       <SearchProgramaticSet open={false} />
       <PageTitle title='Items & Requests' />
       <div className='row'>
         <div className='col-md-8 col-sm-7'>
+          <StaticAlert slug='personal' preview={preview} />
           <Recommendations />
           <div><LoanResources /></div>
           <StaticBody slug='personal' preview={preview} />

--- a/src/components/Settings/presenter.js
+++ b/src/components/Settings/presenter.js
@@ -6,6 +6,7 @@ import SearchProgramaticSet from '../SearchProgramaticSet'
 import LogOut from '../LogOut'
 import StaticSidebar from '../Contentful/StaticContent/Sidebar'
 import StaticBody from '../Contentful/StaticContent/Body'
+import StaticAlert from '../Contentful/StaticContent/Alert'
 import Dropdown from '../Dropdown'
 import UpdateStatus from './settingsUpdateStatus'
 
@@ -18,6 +19,7 @@ const Presenter = (props) => {
       <PageTitle title='Settings' />
       <div className='row'>
         <div className='col-md-8 col-sm-7 settings'>
+          <StaticAlert slug='settings' preview={props.preview} />
           <p>
             Preferred Pickup Location:
           </p>


### PR DESCRIPTION
Adding a `StaticAlert` component in order to add alerts to static page content, very similar to the `StaticBody` and `StaticSidebar` components.

Adding alerts to ColumnContainer pages as well (eg. /services). 

**NOTE** This PR also includes the changes to the CI to build to dev-staging. 