### PR TITLE
ILL Renew all message

### DIFF
--- a/src/actions/personal/alephRenewal.js
+++ b/src/actions/personal/alephRenewal.js
@@ -11,7 +11,7 @@ const requestRenewal = (barcode) => {
   }
 }
 
-const recieveRenewal = (barcode, state, json) => {
+export const recieveRenewal = (barcode, state, json) => {
   return {
     type: RECEIVE_RENEWAL,
     barcode: barcode,

--- a/src/components/LoanResources/ResourceList/Resource/Actions/index.js
+++ b/src/components/LoanResources/ResourceList/Resource/Actions/index.js
@@ -18,10 +18,10 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
 
 export const mapStateToProps = (state, ownProps) => {
   const { itemAction } = state
-  const { renewal, item, itemType } = ownProps
+  const { renewal, item, borrowed } = ownProps
 
   let renewMessage
-  if (renewal && renewal[item.barcode] && itemType !== 'Pending') {
+  if (renewal && renewal[item.barcode] && borrowed) {
     let itemRenew = renewal[item.barcode].data
     if (itemRenew.statusText) {
       renewMessage = itemRenew.statusText

--- a/src/components/LoanResources/ResourceList/Resource/Actions/index.js
+++ b/src/components/LoanResources/ResourceList/Resource/Actions/index.js
@@ -18,23 +18,23 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
 
 export const mapStateToProps = (state, ownProps) => {
   const { itemAction } = state
-  const { renewal, item } = ownProps
+  const { renewal, item, itemType } = ownProps
 
-  let alephMessage
-  if (renewal && renewal[item.barcode]) {
+  let renewMessage
+  if (renewal && renewal[item.barcode] && itemType !== 'Pending') {
     let itemRenew = renewal[item.barcode].data
     if (itemRenew.statusText) {
-      alephMessage = itemRenew.statusText
+      renewMessage = itemRenew.statusText
     } else if (itemRenew.renewStatus === 304) {
-      alephMessage = 'Too early to renew. Try again closer to due date.'
+      renewMessage = 'Too early to renew. Try again closer to due date.'
     } else if (itemRenew.renewStatus === 200) {
-      alephMessage = 'Renew Successful'
+      renewMessage = 'Renew Successful'
     }
   }
 
   return {
     actionResponse: itemAction,
-    alephMessage: alephMessage,
+    renewMessage: renewMessage,
     illWebUrl: Config.illiadBaseURL.replace('<<form>>', illWebForm).replace('<<value>>', item.transactionNumber),
     illViewUrl: Config.illiadBaseURL.replace('<<form>>', illViewForm).replace('<<value>>', item.transactionNumber),
     ...ownProps,

--- a/src/components/LoanResources/ResourceList/Resource/Actions/presenter.js
+++ b/src/components/LoanResources/ResourceList/Resource/Actions/presenter.js
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types'
 import Link from '../../../../Link'
 import * as Statuses from '../../../../../constants/APIStatuses'
 
+const ILLRenew = (item, message) => {
+  if (message && item.transactionNumber) {
+    return <span className='failure'>{message}</span>
+  }
+}
+
 const IllWeb = (item, url) => {
   if (!item.transactionNumber) {
     return null
@@ -31,7 +37,7 @@ const IllView = (item, url) => {
   )
 }
 
-const AlephRenew = (item, renewal, onRenewClick, alephMessage) => {
+const AlephRenew = (item, renewal, onRenewClick, renewMessage) => {
   if (item.status === 'On Loan') {
     if (renewal && renewal[item.barcode]) {
       if (renewal[item.barcode].state === Statuses.FETCHING) {
@@ -45,9 +51,9 @@ const AlephRenew = (item, renewal, onRenewClick, alephMessage) => {
       }
     }
 
-    if (alephMessage) {
+    if (renewMessage) {
       let messageClass = 'status' + renewal[item.barcode].data.renewStatus === 200 ? ' success' : ' failure'
-      return (<span className={messageClass}>{alephMessage}</span>)
+      return (<span className={messageClass}>{renewMessage}</span>)
     } else {
       return (<button onClick={onRenewClick}>Renew</button>)
     }
@@ -67,7 +73,8 @@ export const hasActions = (item) => {
 const Actions = (props) => {
   return (
     <div>
-      { AlephRenew(props.item, props.renewal, props.onRenewClick, props.alephMessage) }
+      { AlephRenew(props.item, props.renewal, props.onRenewClick, props.renewMessage) }
+      { ILLRenew(props.item, props.renewMessage) }
       { IllWeb(props.item, props.illWebUrl) }
       { IllView(props.item, props.illViewUrl) }
     </div>
@@ -78,7 +85,7 @@ Actions.propTypes = {
   item: PropTypes.object.isRequired,
   onRenewClick: PropTypes.func.isRequired,
   renewal: PropTypes.object,
-  alephMessage: PropTypes.string,
+  renewMessage: PropTypes.string,
   illWebUrl: PropTypes.string,
   illViewUrl: PropTypes.string,
 }

--- a/src/components/LoanResources/ResourceList/Resource/index.js
+++ b/src/components/LoanResources/ResourceList/Resource/index.js
@@ -19,7 +19,7 @@ class ResourceContainer extends Component {
     let item = this.props.item
     let renewal = this.props.renewal ? this.props.renewal[item.barcode] : null
     let previousDueDate = item.dueDate
-    if (renewal) {
+    if (renewal && this.props.itemType !== 'Pending') {
       if (renewal.data.renewStatus === 200 && previousDueDate !== renewal.data.dueDate) {
         item.dueDate = renewal.data.dueDate
       }

--- a/src/components/LoanResources/ResourceList/Resource/index.js
+++ b/src/components/LoanResources/ResourceList/Resource/index.js
@@ -19,7 +19,7 @@ class ResourceContainer extends Component {
     let item = this.props.item
     let renewal = this.props.renewal ? this.props.renewal[item.barcode] : null
     let previousDueDate = item.dueDate
-    if (renewal && this.props.itemType !== 'Pending') {
+    if (renewal && this.props.borrowed) {
       if (renewal.data.renewStatus === 200 && previousDueDate !== renewal.data.dueDate) {
         item.dueDate = renewal.data.dueDate
       }
@@ -41,6 +41,12 @@ class ResourceContainer extends Component {
   render () {
     return <Presenter toggleHidden={this.toggleHidden} hidden={this.state.hidden} {...this.props} />
   }
+}
+
+ResourceContainer.propTypes = {
+  renewal: PropTypes.object,
+  item: PropTypes.object,
+  borrowed: PropTypes.bool,
 }
 
 export const mapStateToProps = (state, ownProps) => {

--- a/src/components/LoanResources/ResourceList/Resource/presenter.js
+++ b/src/components/LoanResources/ResourceList/Resource/presenter.js
@@ -39,7 +39,7 @@ const Resource = (props) => {
 
       { actionsButton(props.item, props.toggleHidden) }
       <div className={'actions' + (props.hidden ? '-hidden' : '')}>
-        <Actions item={props.item} alephId={props.alephId} renewal={props.renewal} itemType={props.itemType} />
+        <Actions item={props.item} alephId={props.alephId} renewal={props.renewal} borrowed={props.borrowed} />
       </div>
     </div>
   )
@@ -48,6 +48,9 @@ const Resource = (props) => {
 Resource.propTypes = {
   item: PropTypes.object.isRequired,
   renewal: PropTypes.object,
+  toggleHidden: PropTypes.func,
+  alephId: PropTypes.string,
+  borrowed: PropTypes.bool,
 }
 
 export default Resource

--- a/src/components/LoanResources/ResourceList/Resource/presenter.js
+++ b/src/components/LoanResources/ResourceList/Resource/presenter.js
@@ -20,7 +20,7 @@ const actionsButton = (item, toggleHidden) => {
   }
 }
 
-const ResourceList = (props) => {
+const Resource = (props) => {
   return (
     <div className='card-item' aria-label={props.item.title}>
       <div className='card-header'>
@@ -39,15 +39,15 @@ const ResourceList = (props) => {
 
       { actionsButton(props.item, props.toggleHidden) }
       <div className={'actions' + (props.hidden ? '-hidden' : '')}>
-        <Actions item={props.item} alephId={props.alephId} renewal={props.renewal} />
+        <Actions item={props.item} alephId={props.alephId} renewal={props.renewal} itemType={props.itemType} />
       </div>
     </div>
   )
 }
 
-ResourceList.propTypes = {
+Resource.propTypes = {
   item: PropTypes.object.isRequired,
   renewal: PropTypes.object,
 }
 
-export default ResourceList
+export default Resource

--- a/src/components/LoanResources/ResourceList/index.js
+++ b/src/components/LoanResources/ResourceList/index.js
@@ -3,9 +3,10 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
-import { renewAleph } from '../../../actions/personal/alephRenewal'
+import { renewAleph, recieveRenewal } from '../../../actions/personal/alephRenewal'
 import Loading from '../../Messages/InlineLoading'
 import Presenter from './presenter'
+import * as statuses from '../../../constants/APIStatuses'
 
 class ListContainer extends Component {
   constructor (props) {
@@ -166,11 +167,14 @@ export const mapStateToProps = (state, ownProps) => {
 export const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     renewAll: (e) => {
+      // renew all aleph items
       ownProps.list.forEach((item) => {
         if (item.barcode) {
           dispatch(renewAleph(item.barcode, ownProps.alephId))
         }
       })
+      // set renewal of illiad items
+      dispatch(recieveRenewal(undefined, statuses.SUCCESS, { statusText: 'Please view item in ILL to renew' }))
     },
   }
 }

--- a/src/components/LoanResources/ResourceList/presenter.js
+++ b/src/components/LoanResources/ResourceList/presenter.js
@@ -68,6 +68,7 @@ const ResourceList = (props) => {
                 renewal={props.renewal}
                 alephId={props.alephId}
                 borrowed={props.borrowed}
+                itemType={props.listType}
                 key={index}
               />
             )

--- a/src/components/LoanResources/ResourceList/presenter.js
+++ b/src/components/LoanResources/ResourceList/presenter.js
@@ -68,7 +68,6 @@ const ResourceList = (props) => {
                 renewal={props.renewal}
                 alephId={props.alephId}
                 borrowed={props.borrowed}
-                itemType={props.listType}
                 key={index}
               />
             )

--- a/src/tests/components/LoanResources/ResourceList/Resource/Actions/index.test.js
+++ b/src/tests/components/LoanResources/ResourceList/Resource/Actions/index.test.js
@@ -36,10 +36,10 @@ describe('components/LoanResources/ResourceList/Resource/Actions/index.js', () =
       state = undefined
     })
 
-    it('should contain the statusText as the alephMessage', () => {
+    it('should contain the statusText as the renewMessage', () => {
       let item = props.item
       let renewal = props.renewal
-      expect(mapStateToProps(state, props)).toHaveProperty('alephMessage', renewal[item.barcode].data.statusText)
+      expect(mapStateToProps(state, props)).toHaveProperty('renewMessage', renewal[item.barcode].data.statusText)
     })
 
     it('should have the correct actionResponse', () => {
@@ -84,10 +84,10 @@ describe('components/LoanResources/ResourceList/Resource/Actions/index.js', () =
       state = undefined
     })
 
-    it('should contain the text for renewStatus = 304 as the alephMessage', () => {
+    it('should contain the text for renewStatus = 304 as the renewMessage', () => {
       let item = props.item
       let renewal = props.renewal
-      expect(mapStateToProps(state, props)).toHaveProperty('alephMessage', 'Too early to renew. Try again closer to due date.')
+      expect(mapStateToProps(state, props)).toHaveProperty('renewMessage', 'Too early to renew. Try again closer to due date.')
     })
   })
 
@@ -118,10 +118,10 @@ describe('components/LoanResources/ResourceList/Resource/Actions/index.js', () =
       state = undefined
     })
 
-    it('should contain the alephMessage for renewStatus = 200', () => {
+    it('should contain the renewMessage for renewStatus = 200', () => {
       let item = props.item
       let renewal = props.renewal
-      expect(mapStateToProps(state, props)).toHaveProperty('alephMessage', 'Renew Successful')
+      expect(mapStateToProps(state, props)).toHaveProperty('renewMessage', 'Renew Successful')
     })
   })
 

--- a/src/tests/components/LoanResources/ResourceList/Resource/Actions/index.test.js
+++ b/src/tests/components/LoanResources/ResourceList/Resource/Actions/index.test.js
@@ -24,6 +24,7 @@ describe('components/LoanResources/ResourceList/Resource/Actions/index.js', () =
             },
           },
         },
+        borrowed: true,
       }
 
       state = {
@@ -68,10 +69,11 @@ describe('components/LoanResources/ResourceList/Resource/Actions/index.js', () =
         renewal: {
           test: {
             data: {
-              renewStatus: 304
+              renewStatus: 304,
             },
           },
         },
+        borrowed: true,
       }
 
       state = {
@@ -102,10 +104,11 @@ describe('components/LoanResources/ResourceList/Resource/Actions/index.js', () =
         renewal: {
           test: {
             data: {
-              renewStatus: 200
+              renewStatus: 200,
             },
           },
         },
+        borrowed: true,
       }
 
       state = {
@@ -133,7 +136,8 @@ describe('components/LoanResources/ResourceList/Resource/Actions/index.js', () =
           transactionNumber: 123456789,
         },
         alephId: 1234,
-        renewal: null
+        renewal: null,
+        borrowed: true,
       }
 
       state = {
@@ -146,10 +150,10 @@ describe('components/LoanResources/ResourceList/Resource/Actions/index.js', () =
       state = undefined
     })
 
-    it('should contain undefined as the alephMessage', () => {
+    it('should contain undefined as the renewMessage', () => {
       let item = props.item
       let renewal = props.renewal
-      expect(mapStateToProps(state, props)).toHaveProperty('alephMessage', undefined)
+      expect(mapStateToProps(state, props)).toHaveProperty('renewMessage', undefined)
     })
   })
 })


### PR DESCRIPTION
When renew all is clicked, ILL items didn't show any message about why they weren't renewed. This adds a message saying "view item in ILL to renew"

This change was quite a bit more complicated than it seemed - the while of items & requests code should be refactored at some point.

I also took this as a time to rename a few classes/variables to make it easier to read and debug.