### PR TITLE
Make sure presenter info always has background

### DIFF
--- a/src/components/Contentful/Event/presenter.js
+++ b/src/components/Contentful/Event/presenter.js
@@ -51,6 +51,7 @@ const PagePresenter = ({ entry }) => {
           }
           <LibMarkdown itemProp='description'>{ entry.content }</LibMarkdown>
           <Related className='p-resources' title='Resources' showImages={false}>{ entry.relatedResources }</Related>
+          <Presenters presenters={entry.presenters} />
           <ShareLinks title={entry.title} />
           <AddToCalendar
             title={entry.title}

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -2118,8 +2118,9 @@ width: 100%;
   -webkit-box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.25);
   -moz-box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.25);
   box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.25);
-  padding: 1em;
+  padding: 1em 1em 0 1em;
   margin-bottom: 1.5em;
+  overflow: hidden;
 }
 
 .sponsors {
@@ -2139,6 +2140,10 @@ width: 100%;
   margin-bottom: 10px;
 }
 
+.presenter-card .vcard {
+  padding-bottom: 1em;
+}
+
 .presenter-card .n, .presenter-card .org, .presenter-card .email, .presenter-card .tel, .sponsors .sponsor-detail {
   color: #001E45;
   font-family: GPCMed, sans-serif;
@@ -2156,7 +2161,7 @@ width: 100%;
 }
 
 .presenter-card .bio p {
-  margin: 1em 0;
+  margin: 1em 0 0 0;
   font-size: 14px;
   color: #001E45;
   max-width: none;
@@ -2167,9 +2172,8 @@ width: 100%;
   border: none;
   max-width: 160px;
   box-shadow: none;
-  margin-right: 15px;
   float: left;
-  margin-bottom: 40px;
+  margin: 0 1em 1em 0;
 }
 
 .shareLinks {


### PR DESCRIPTION
Also, re-enable presenters on events.

Magic: if you put `overflow: hidden` on a parent with floating children, that parent will grow to the size of it's children.
https://stackoverflow.com/questions/9463069/grow-height-of-parent-div-that-contains-floating-nested-divs