### PR TITLE
LW-352 - Search box on home page extends below background image

### DIFF
--- a/src/components/SearchDrawer/presenter.js
+++ b/src/components/SearchDrawer/presenter.js
@@ -1,4 +1,4 @@
-'use strict'
+
 import React from 'react'
 import PropTypes from 'prop-types'
 import SearchPreference from './SearchPreference'
@@ -10,8 +10,9 @@ import '../../static/css/global.css'
 import '../../static/css/search.css'
 
 const Drawer = (props) => {
+  const sectionClasses = props.search.advancedSearch ? 'advanaced' : ''
   return (
-    <section id='drawer' role='search' aria-hidden='false'>
+    <section id='drawer' role='search' aria-hidden='false' className={sectionClasses}>
       <div className='appliance'>
         <form id='searchAppliance'>
           <SearchBox

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -3169,6 +3169,29 @@ width: 100%;
   }
 }
 
+@media screen and (max-width: 1570px) {
+  .advanaced .appliance, .home .advanaced .appliance {
+    left: 0 !important;
+  }
+
+   .home .advanaced .appliance {
+    left: 0;
+    top: 0;
+    width: 100%;
+    padding: 24px;
+    max-width: 100%;
+  }
+
+  .advanaced .appliance ul {
+    width: 100%;
+    cursor: pointer;
+  }
+   #drawer.advanaced, .home #drawer.advanaced {
+    height: auto;
+    min-height: auto;
+  }
+}
+
 #save-preference {
   cursor: pointer;
   display: inline-block;


### PR DESCRIPTION
Search box on home page extends below background image for advanced search.

**OLD:**
![screen shot 2018-03-05 at 1 17 56 pm](https://user-images.githubusercontent.com/416559/36992046-a9e8614e-2077-11e8-8e25-f74a1d0d30e3.png)

**NEW:**
![screen shot 2018-03-05 at 1 16 31 pm](https://user-images.githubusercontent.com/416559/36991997-80d2693a-2077-11e8-8498-a4bca8e24ffa.png)