### PR TITLE
Show all database links on resources landing page

### DIFF
--- a/src/components/Contentful/Page/columnPresenter.js
+++ b/src/components/Contentful/Page/columnPresenter.js
@@ -20,23 +20,23 @@ const Sections = (column, showDescriptions) => {
         <div className='linksgroup'>
           <div role={s.title + ' navigation'}>
             {
-            s.links.map((item) => {
-              let linkObject = getLinkObject(item.fields, item.sys.id)
-              return (
-                <p key={item.sys.id}>
-                  <Link to={linkObject.heading.url} className='item-title'>{linkObject.heading.title}</Link>
-                  <ul className='linkGroup'>
-                    {
-                      linkObject.conditionalLinks.map((data) => {
-                        return <li key={data.keyId}><Link to={data.url}>{data.title}</Link></li>
-                      })
-                    }
-                  </ul>
-                  { showDescriptions ? (<span>{linkObject.heading.description}</span>) : null }
-                </p>
-              )
-            })
-          }
+              s.links.map((item) => {
+                let linkObject = getLinkObject(item.fields, item.sys.id)
+                return (
+                  <p key={item.sys.id}>
+                    <Link to={linkObject.heading.url} className='item-title'>{linkObject.heading.title}</Link>
+                    <ul className='linkGroup'>
+                      {
+                        linkObject.conditionalLinks.map((data) => {
+                          return <li key={data.keyId}><Link to={data.url}>{data.title}</Link></li>
+                        })
+                      }
+                    </ul>
+                    { showDescriptions ? (<span>{linkObject.heading.description}</span>) : null }
+                  </p>
+                )
+              })
+            }
           </div>
         </div>
       </section>

--- a/src/components/Contentful/Page/columnPresenter.js
+++ b/src/components/Contentful/Page/columnPresenter.js
@@ -6,6 +6,7 @@ import Link from '../../Link'
 import LibMarkdown from '../../LibMarkdown'
 import SideNav from '../../SideNav'
 import PageAlert from '../Alert/Page'
+import { getLinkObject } from '../../../shared/ContentfulLibs'
 
 import './style.css'
 
@@ -20,12 +21,18 @@ const Sections = (column, showDescriptions) => {
           <div role={s.title + ' navigation'}>
             {
             s.links.map((item) => {
-              let link = item.fields.url ? item.fields.url : '/' + item.fields.slug
-              let title = (item.fields.url || item.fields.slug) ? (<Link to={link}>{item.fields.title}</Link>) : (<strong>{item.fields.title}</strong>)
+              let linkObject = getLinkObject(item.fields, item.sys.id)
               return (
                 <p key={item.sys.id}>
-                  {title}
-                  { showDescriptions ? (<span>{item.fields.shortDescription}</span>) : null }
+                  <Link to={linkObject.heading.url} className='item-title'>{linkObject.heading.title}</Link>
+                  <ul className='linkGroup'>
+                    {
+                      linkObject.conditionalLinks.map((data) => {
+                        return <li key={data.keyId}><Link to={data.url}>{data.title}</Link></li>
+                      })
+                    }
+                  </ul>
+                  { showDescriptions ? (<span>{linkObject.heading.description}</span>) : null }
                 </p>
               )
             })

--- a/src/components/DatabaseList/presenter.js
+++ b/src/components/DatabaseList/presenter.js
@@ -12,6 +12,7 @@ import SideNav from '../SideNav'
 import LibMarkdown from '../LibMarkdown'
 import TextEllipsis from 'react-text-ellipsis'
 import Alphabet from './Alphabet'
+import { getLinkObject } from '../../shared/ContentfulLibs'
 import './style.css'
 
 const Content = (letter, data, filterValue, onFilterChange, assistText) => {
@@ -56,36 +57,28 @@ const Loaded = (props) => {
   }
 
   let data = props.list.map((item) => {
-    let exactlyOneUrl = item.fields.urls !== undefined && item.fields.urls.length === 1
-    let twoOrMoreUrls = item.fields.urls !== undefined && item.fields.urls.length >= 2
+    let linkObject = getLinkObject(item.fields, item.sys.id)
+
     return (
       <section key={item.fields.alephSystemNumber + item.fields.title}
         aria-label={item.fields.title} className='dbSection'>
-        {
-          exactlyOneUrl ? (
-            <Link to={item.fields.urls[0].url} title={'Go to ' + item.fields.title}>
-              <h2 className='dbItem'>{item.fields.title}</h2>
-            </Link>
-          ) : (
-            <h2 className='dbItem'>{item.fields.title}</h2>
-          )
-        }
+        <Link to={linkObject.heading.url} title={'Go to ' + item.fields.title}>
+          <h2 className='dbItem'>{item.fields.title}</h2>
+        </Link>
         <ul className='clamp databaseLink'>
           {
-            twoOrMoreUrls && (
-              item.fields.urls.map((data) => {
-                return (
-                  <li key={data.url}>
-                    <Link to={data.url}>{data.title}</Link>
-                    { data.notes && <LibMarkdown>{ data.notes }</LibMarkdown> }
-                  </li>
-                )
-              })
-            )
+            linkObject.conditionalLinks.map((link) => {
+              return (
+                <li key={link.keyId}>
+                  <Link to={link.url}>{link.title}</Link>
+                  { link.notes && <LibMarkdown>{ link.notes }</LibMarkdown> }
+                </li>
+              )
+            })
           }
         </ul>
         <div className='database-list'>
-          <TextEllipsis lines={3}>{item.fields.description}</TextEllipsis>
+          <TextEllipsis lines={3}>{linkObject.heading.description}</TextEllipsis>
         </div>
         <Link to={'/database/' + item.sys.id} className='moreinfo'
           ariaLabel={'More Information about ' + item.fields.title}>More info</Link>

--- a/src/shared/ContentfulLibs.js
+++ b/src/shared/ContentfulLibs.js
@@ -23,11 +23,13 @@ export const flattenLocale = (fields, locale) => {
 
 // create an unifrom object to make a single mapping function easy in presenters
 export const getLinkObject = (fields, sysId) => {
-  // determine if heading should be a link
+  // We need to determine if the main heading (entry title) should be a link
+  //  The resource type has links in the "urls" json field. If there is only one, make it the heading link
+  //  If we're not handling a resource type the heading should be linked with its appropriate url field (below)
   let shouldHaveMain = !fields.urls || fields.urls.length === 1
   let mainUrl = (shouldHaveMain && fields.urls) ? fields.urls[0].url : ''
 
-  // get correct field for main link
+  // If we're not handling a resoruce type, get the link to use for the heading
   if (!mainUrl && shouldHaveMain) {
     if (fields.url) {
       mainUrl = fields.url
@@ -38,10 +40,12 @@ export const getLinkObject = (fields, sysId) => {
     }
   }
 
-  // get description field
+  // get appropriate description field for this content type
   let desc = fields.shortDescription ? fields.shortDescription : fields.description
 
-  // make list of links, either map all resource "urls" or a single link from the above mainurl
+  // Make a list of all links for this object, for the resource type it's the entire "urls" field
+  //  otherwise, we've already got the only link for the object in the mainUrl var
+  //  we also want to enrich the data with a title if there is none, and a keyId for use in displays <li key={keyId}>
   let links
   if (fields.urls) {
     links = fields.urls.map((data, index) => {

--- a/src/shared/ContentfulLibs.js
+++ b/src/shared/ContentfulLibs.js
@@ -23,9 +23,11 @@ export const flattenLocale = (fields, locale) => {
 
 // create an unifrom object to make a single mapping function easy in presenters
 export const getLinkObject = (fields, sysId) => {
+  // determine if heading should be a link
   let shouldHaveMain = !fields.urls || fields.urls.length === 1
   let mainUrl = (shouldHaveMain && fields.urls) ? fields.urls[0].url : ''
 
+  // get correct field for main link
   if (!mainUrl && shouldHaveMain) {
     if (fields.url) {
       mainUrl = fields.url
@@ -36,9 +38,10 @@ export const getLinkObject = (fields, sysId) => {
     }
   }
 
+  // get description field
   let desc = fields.shortDescription ? fields.shortDescription : fields.description
 
-  // make list of links
+  // make list of links, either map all resource "urls" or a single link from the above mainurl
   let links
   if (fields.urls) {
     links = fields.urls.map((data, index) => {
@@ -50,6 +53,9 @@ export const getLinkObject = (fields, sysId) => {
     links = [ { title: fields.title, url: mainUrl, keyId: sysId + 'link' + 0 } ]
   }
 
+  // heading is the item title, url, and description
+  // links are all possible links
+  // conditionalLinks is all links if there is no main link (for instance, resources with more than 1 url)
   return {
     heading: { title: fields.title, url: mainUrl, description: desc },
     links: links,

--- a/src/shared/ContentfulLibs.js
+++ b/src/shared/ContentfulLibs.js
@@ -20,3 +20,39 @@ export const flattenLocale = (fields, locale) => {
     }
   })
 }
+
+// create an unifrom object to make a single mapping function easy in presenters
+export const getLinkObject = (fields, sysId) => {
+  let shouldHaveMain = !fields.urls || fields.urls.length === 1
+  let mainUrl = (shouldHaveMain && fields.urls) ? fields.urls[0].url : ''
+
+  if (!mainUrl && shouldHaveMain) {
+    if (fields.url) {
+      mainUrl = fields.url
+    } else if (fields.purl) {
+      mainUrl = fields.purl
+    } else if (fields.slug) {
+      mainUrl = '/' + fields.slug
+    }
+  }
+
+  let desc = fields.shortDescription ? fields.shortDescription : fields.description
+
+  // make list of links
+  let links
+  if (fields.urls) {
+    links = fields.urls.map((data, index) => {
+      data.keyId = sysId + 'link' + index
+      data.title = data.title ? data.title : fields.title
+      return data
+    })
+  } else {
+    links = [ { title: fields.title, url: mainUrl, keyId: sysId + 'link' + 0 } ]
+  }
+
+  return {
+    heading: { title: fields.title, url: mainUrl, description: desc },
+    links: links,
+    conditionalLinks: mainUrl ? [] : links,
+  }
+}

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -151,8 +151,13 @@ height:auto;
   max-width: 840px;
 }
 
-.landing p a, .landing .child li a, .landing p strong {
+.landing p a, .landing .child li a, .landing p .item-title {
   font-size: 110%;
+}
+
+.landing p .item-title {
+  font-weight: bold;
+  margin-left: 0;
 }
 
 .landing .child li:before {
@@ -1580,7 +1585,7 @@ aside section .p-pages {
 }
 
 
-.databaseLink p {
+.databaseLink p, .linkGroup p {
   padding-left: 12px;
   font-weight: normal;
 }
@@ -2506,11 +2511,20 @@ width: 100%;
   padding-bottom: 0 !important;
 }
 
-.p-resources, .databaseLink {
+.p-resources, .databaseLink, .linkGroup {
   list-style: outside none none;
   padding: 0;
 
   margin-bottom: 3em;
+}
+
+.linkGroup {
+  margin: 0;
+}
+
+.linkGroup li a {
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .p-pages {
@@ -2554,7 +2568,7 @@ width: 100%;
   }
 }
 
-.p-resources li, .databaseLink li {
+.p-resources li, .databaseLink li, .linkGroup li {
   list-style: none;
   width: auto;
   float: none;
@@ -2562,7 +2576,7 @@ width: 100%;
   position: relative;
 }
 
-.p-resources li::before , .p-pages li::before, .databaseLink li::before {
+.p-resources li::before , .p-pages li::before, .databaseLink li::before, .linkGroup li::before {
   color: #b3b3b3;
   content: "›";
   left: 3px;

--- a/src/tests/shared/ContentfulLibs.test.js
+++ b/src/tests/shared/ContentfulLibs.test.js
@@ -1,0 +1,106 @@
+import { getLinkObject } from '../../shared/ContentfulLibs'
+
+describe('getLinkObject', () => {
+  const testUrl = 'testUrl'
+
+  describe('urls field', () => {
+    describe('single url', () => {
+      const fields = {
+        title: 'fieldTitle',
+        urls: [ { title: 'title', url: testUrl } ],
+      }
+
+      it('Should have a main url', () => {
+        expect(getLinkObject(fields, 0)).toHaveProperty('heading.url', testUrl)
+      })
+
+      it('Should return with all links', () => {
+        expect(getLinkObject(fields, 0)).toHaveProperty('links')
+      })
+
+      it('Should return empty conditional links', () => {
+        expect(getLinkObject(fields, 0)).toHaveProperty('conditionalLinks', [])
+      })
+    })
+
+    describe('multiple urls', () => {
+      const fields = {
+        title: 'fieldTitle',
+        urls: [ { title: 'first', url: testUrl }, { title: 'second', url: testUrl } ],
+      }
+
+      it('Should not have a main url', () => {
+        expect(getLinkObject(fields, 0)).toHaveProperty('heading.url', '')
+      })
+
+      it('Should return with all links', () => {
+        expect(getLinkObject(fields, 0)).toHaveProperty('links')
+      })
+
+      it('Should return with conditional links', () => {
+        const ret = getLinkObject(fields, 0)
+        expect(ret).toHaveProperty('conditionalLinks')
+        expect(ret.conditionalLinks.length).toBe(fields.urls.length)
+      })
+    })
+  })
+
+  describe('url field', () => {
+    let fields = {
+      title: 'fieldTitle',
+      url: testUrl,
+    }
+
+    it('Should have a main url', () => {
+      expect(getLinkObject(fields, 0)).toHaveProperty('heading.url', testUrl)
+    })
+
+    it('Should return with all links', () => {
+      expect(getLinkObject(fields, 0)).toHaveProperty('links', [ { title: fields.title, url: fields.url, keyId: '0link0' } ])
+    })
+
+    it('Should return empty conditional links', () => {
+      expect(getLinkObject(fields, 0)).toHaveProperty('conditionalLinks', [])
+    })
+  })
+
+  describe('purl field', () => {
+    let fields = {
+      title: 'fieldTitle',
+      purl: testUrl,
+    }
+
+    it('Should have a main url', () => {
+      expect(getLinkObject(fields, 0)).toHaveProperty('heading.url', testUrl)
+    })
+
+    it('Should return with all links', () => {
+      expect(getLinkObject(fields, 0))
+        .toHaveProperty('links', [ { title: fields.title, url: fields.purl, keyId: '0link0' } ])
+    })
+
+    it('Should return empty conditional links', () => {
+      expect(getLinkObject(fields, 0)).toHaveProperty('conditionalLinks', [])
+    })
+  })
+
+  describe('slug field', () => {
+    let fields = {
+      title: 'fieldTitle',
+      slug: testUrl,
+    }
+
+    it('Should have a main url', () => {
+      expect(getLinkObject(fields, 0)).toHaveProperty('heading.url', '/' + testUrl)
+    })
+
+    it('Should return with all links', () => {
+      expect(getLinkObject(fields, 0))
+        .toHaveProperty('links', [ { title: fields.title, url: '/' + fields.slug, keyId: '0link0' } ])
+    })
+
+    it('Should return empty conditional links', () => {
+      expect(getLinkObject(fields, 0)).toHaveProperty('conditionalLinks', [])
+    })
+  })
+})


### PR DESCRIPTION
Created a helper method to create a common `linkObject` from any contentful entry. This allows us to remove complicated conditionals in presenters when trying to display links, particularly with resource entries, but it can also be used for many others.