### PR TITLE
LW 380 & LW366

### DIFF
--- a/src/components/Contentful/Event/index.js
+++ b/src/components/Contentful/Event/index.js
@@ -24,7 +24,7 @@ const mapStateToProps = (state) => {
 
     let start = makeLocalTimezone(fields.startDate)
     let end = endDate ? makeLocalTimezone(fields.endDate) : makeLocalTimezone(fields.startDate)
-    let displayTime = fields.timeOverride ? fields.timeOverride : `${hour12(start)} - ${hour12(end)}`
+    let displayTime = fields.timeOverride ? fields.timeOverride : `${hour12(start)} &ndash; ${hour12(end)}`
 
     data = {
       ...data.fields,

--- a/src/components/Contentful/News/presenter.js
+++ b/src/components/Contentful/News/presenter.js
@@ -16,7 +16,7 @@ import OpenGraph from '../../OpenGraph'
 
 const PagePresenter = ({ entry }) => (
   <article
-    className='container-fluid content-area'
+    className='container-fluid content-area news-article'
     itemScope
     itemType='http://schema.org/NewsArticle'
     itemProp='mainEntity'

--- a/src/components/Contentful/News/style.css
+++ b/src/components/Contentful/News/style.css
@@ -1,3 +1,6 @@
 .headline {
 	max-width: 30ch;
 }
+.news-article h1 {
+  max-width: 100%;
+}

--- a/src/components/Contentful/News/style.css
+++ b/src/components/Contentful/News/style.css
@@ -1,6 +1,3 @@
-.headline {
-	max-width: 30ch;
-}
 .news-article h1 {
   max-width: 100%;
 }


### PR DESCRIPTION
**LW380:** Users want to see a headline on an individual news story that extends to the full width of the column.

- Add css wrapping class for news. Add css style to set wrapped h1 to 100% width.

**LW366:** Users need to see an en dash between between start and end times on individual events.

- Change regular hyphen/dash to `&ndash;`