### PR TITLE
LW-380 Users want to see a headline on an individual news story that extends to the full width of the column.

### DIFF
--- a/src/components/Contentful/News/presenter.js
+++ b/src/components/Contentful/News/presenter.js
@@ -22,7 +22,7 @@ const PagePresenter = ({ entry }) => (
     itemProp='mainEntity'
   >
     {entry.fields.shortDescription && (<meta name='description' content={entry.fields.shortDescription} />) }
-    <PageTitle title={entry.fields.title} itemProp='headline'>
+    <PageTitle title={entry.fields.title} itemProp='headline' classes='col-md-8 col-sm-8'>
       <div className='tagline news'>
         { entry.fields.author && <div className='author'>{ 'By ' + entry.fields.author }</div> }
         { entry.fields.publishedDate && (

--- a/src/components/Contentful/News/style.css
+++ b/src/components/Contentful/News/style.css
@@ -1,3 +1,0 @@
-.news-article h1 {
-  max-width: 100%;
-}

--- a/src/components/PageTitle/index.js
+++ b/src/components/PageTitle/index.js
@@ -1,4 +1,4 @@
-'use strict'
+
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
@@ -26,7 +26,11 @@ class PageTitle extends Component {
 
     return (
       <header className='page-title'>
-        <h1 id='main-page-title' itemProp={this.props.itemProp}>
+        <h1
+          id='main-page-title'
+          itemProp={this.props.itemProp}
+          className={this.props.classes}
+        >
           {this.props.title}
           { this.props.subtitle && <small>{this.props.subtitle}</small> }
         </h1>
@@ -44,6 +48,7 @@ PageTitle.propTypes = {
   hideInPage: PropTypes.bool,
   itemProp: PropTypes.string,
   children: PropTypes.any,
+  classes: PropTypes.string,
 }
 
 PageTitle.defaultProps = {


### PR DESCRIPTION
Revised:

Make title width of text column

![screen shot 2018-03-26 at 3 24 23 pm](https://user-images.githubusercontent.com/416559/37928129-d13e12fa-3109-11e8-892c-79b8d3b73063.png)
