### PR TITLE
Add floor search page so NUI can redirect here for floor maps

### DIFF
--- a/src/actions/floorSearch.js
+++ b/src/actions/floorSearch.js
@@ -1,0 +1,44 @@
+import fetch from 'isomorphic-fetch'
+import * as statuses from '../constants/APIStatuses'
+import Config from '../shared/Configuration'
+
+export const FLOOR_SEARCH_REQUEST = 'FLOOR_SEARCH_REQUEST'
+export const FLOOR_SEARCH_RECEIVE = 'FLOOR_SEARCH_RECEIVE'
+
+export const requestFloorSearch = () => {
+  return {
+    type: FLOOR_SEARCH_REQUEST,
+  }
+}
+
+const receiveFloorSearch = (response) => {
+  if (response.stack === 'TypeError: Failed to fetch') {
+    return {
+      type: FLOOR_SEARCH_RECEIVE,
+      status: statuses.ERROR,
+      error: response,
+      slug: '',
+      receivedAt: Date.now(),
+    }
+  } else {
+    return {
+      type: FLOOR_SEARCH_RECEIVE,
+      status: statuses.SUCCESS,
+      slug: response.slug,
+      receivedAt: Date.now(),
+    }
+  }
+}
+
+const searchFloorMaps = (searchQuery) => {
+  return dispatch => {
+    dispatch(requestFloorSearch())
+    let url = Config.contentfulAPI + '/map' + searchQuery
+    return fetch(url)
+      .then(response => response.json())
+      .then(json => dispatch(receiveFloorSearch(json)))
+      .catch(error => dispatch(receiveFloorSearch(error)))
+  }
+}
+
+export default searchFloorMaps

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -22,6 +22,7 @@ import Contact from '../LandingPages/Contact'
 import DatabaseList from '../../components/DatabaseList'
 import SubjectList from '../../components/SubjectList'
 import SiteInfo from '../../components/SiteInfo'
+import FloorSearch from '../../components/FloorSearch'
 import rootReducers from '../../reducers'
 import thunkMiddleware from 'redux-thunk'
 import Rewrite from './Rewrite'
@@ -75,6 +76,7 @@ const App = (props) => {
               <Route exact path='/events/:date' component={Events} />
               <Route exact path='/news' component={News} />
               <Route exact path='/contact-us' component={Contact} />
+              <Route exact path='/floor/search' component={FloorSearch} />
               <Route exact path='/floor/:id' component={ContentfulFloor} />
               <Route exact path='/news/:id' component={ContentfulNews} />
               <Route exact path='/event/:id' component={ContentfulEvent} />

--- a/src/components/Contentful/Floor/index.js
+++ b/src/components/Contentful/Floor/index.js
@@ -11,7 +11,7 @@ const mapStateToProps = (state, ownProps) => {
   const searchParams = new URLSearchParams(ownProps.location.search)
   let extraData = {}
 
-  const extraFields = [ 'title', 'author', 'call_number' ]
+  const extraFields = [ 'title', 'author', 'call_number', 'collection_display' ]
   for (let fieldIndex in extraFields) {
     let field = extraFields[fieldIndex]
     if (searchParams.get(field)) {

--- a/src/components/Contentful/Floor/index.js
+++ b/src/components/Contentful/Floor/index.js
@@ -50,6 +50,7 @@ ContentfulFloorContainer.propTypes = {
   cfFloorEntry: PropTypes.object.isRequired,
   match: PropTypes.object.isRequired,
   searchParams: PropTypes.object.isRequired,
+  extraData: PropTypes.object,
 }
 
 const ContentfulFloor = connect(

--- a/src/components/Contentful/Floor/index.js
+++ b/src/components/Contentful/Floor/index.js
@@ -7,8 +7,23 @@ import PropTypes from 'prop-types'
 import PresenterFactory from '../../APIPresenterFactory'
 import ContentfulFloorPresenter from './presenter.js'
 
-const mapStateToProps = (state) => {
-  return { cfFloorEntry: state.cfFloorEntry }
+const mapStateToProps = (state, ownProps) => {
+  const searchParams = new URLSearchParams(ownProps.location.search)
+  let extraData = {}
+
+  const extraFields = [ 'title', 'author', 'call_number' ]
+  for (let fieldIndex in extraFields) {
+    let field = extraFields[fieldIndex]
+    if (searchParams.get(field)) {
+      extraData[field] = searchParams.get(field)
+    }
+  }
+
+  return {
+    cfFloorEntry: state.cfFloorEntry,
+    searchParams: searchParams,
+    extraData: extraData,
+  }
 }
 
 const mapDispatchToProps = (dispatch) => {
@@ -18,7 +33,7 @@ const mapDispatchToProps = (dispatch) => {
 export class ContentfulFloorContainer extends Component {
   componentDidMount () {
     let pageSlug = this.props.match.params.id
-    const preview = (new URLSearchParams(this.props.location.search)).get('preview') === 'true'
+    const preview = this.props.searchParams.get('preview') === 'true'
     this.props.fetchFloor(pageSlug, preview)
   }
 
@@ -26,7 +41,7 @@ export class ContentfulFloorContainer extends Component {
     return <PresenterFactory
       presenter={ContentfulFloorPresenter}
       status={this.props.cfFloorEntry.status}
-      props={{ cfFloorEntry: this.props.cfFloorEntry.json }} />
+      props={{ cfFloorEntry: this.props.cfFloorEntry.json, extraData: this.props.extraData }} />
   }
 }
 
@@ -34,6 +49,7 @@ ContentfulFloorContainer.propTypes = {
   fetchFloor: PropTypes.func.isRequired,
   cfFloorEntry: PropTypes.object.isRequired,
   match: PropTypes.object.isRequired,
+  searchParams: PropTypes.object.isRequired,
 }
 
 const ContentfulFloor = connect(

--- a/src/components/Contentful/Floor/presenter.js
+++ b/src/components/Contentful/Floor/presenter.js
@@ -21,6 +21,7 @@ const FloorPresenter = ({ cfFloorEntry, extraData }) => (
               <h2>{extraData.title}</h2>
               <p className='author'>{extraData.author}</p>
               <p className='callNumber'>{extraData.call_number}</p>
+              <p className='collection'>{extraData.collection_display}</p>
             </div>
           )
         }

--- a/src/components/Contentful/Floor/presenter.js
+++ b/src/components/Contentful/Floor/presenter.js
@@ -9,23 +9,35 @@ import Image from '../../Image'
 import PageTitle from '../../PageTitle'
 import SearchProgramaticSet from '../../SearchProgramaticSet'
 
-const FloorPresenter = ({ cfFloorEntry }) => (
+const FloorPresenter = ({ cfFloorEntry, extraData }) => (
   <div key={`ContentfulFloor_${cfFloorEntry.sys.id}`} className='container-fluid'>
     <PageTitle title={cfFloorEntry.fields.title} />
     <SearchProgramaticSet open={false} />
     <div className='row'>
-    <div className='col-md-9 col-xs-12 floor'><Image cfImage={cfFloorEntry.fields.image} /></div>
-    <div className='col-md-3 col-sxs-12 building'>
-      <LibMarkdown>{cfFloorEntry.fields.shortDescription}</LibMarkdown>
-      { cfFloorEntry.fields.callNumberRange && (<p>Call Number Ranges: {cfFloorEntry.fields.callNumberRange}</p>) }
-      <Building cfBuildingEntry={cfFloorEntry.fields.building} />
-    </div>
+      <div className='col-md-9 col-xs-12 floor'>
+        {
+          Object.keys(extraData).length > 0 && (
+            <div className='item-data'>
+              <h2>{extraData.title}</h2>
+              <p className='author'>{extraData.author}</p>
+              <p className='callNumber'>{extraData.call_number}</p>
+            </div>
+          )
+        }
+        <Image cfImage={cfFloorEntry.fields.image} />
+      </div>
+      <div className='col-md-3 col-sxs-12 building'>
+        <LibMarkdown>{cfFloorEntry.fields.shortDescription}</LibMarkdown>
+        { cfFloorEntry.fields.callNumberRange && (<p>Call Number Ranges: {cfFloorEntry.fields.callNumberRange}</p>) }
+        <Building cfBuildingEntry={cfFloorEntry.fields.building} />
+      </div>
     </div>
   </div>
 )
 
 FloorPresenter.propTypes = {
   cfFloorEntry: PropTypes.object.isRequired,
+  extraData: PropTypes.object,
 }
 
 export default FloorPresenter

--- a/src/components/FloorSearch/index.js
+++ b/src/components/FloorSearch/index.js
@@ -27,7 +27,7 @@ class FloorSearch extends Component {
     // if we found a floor, redirect to that floor, otherwise error
     if (status === statuses.SUCCESS && slug) {
       this.props.history.push(slug + this.props.searchString)
-    } else if (status === statuses.ERROR ||(status === statuses.SUCCESS && !slug)) {
+    } else if (status === statuses.ERROR || (status === statuses.SUCCESS && !slug)) {
       this.setState({ error: true })
     }
   }

--- a/src/components/FloorSearch/index.js
+++ b/src/components/FloorSearch/index.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+
+import searchFloorMaps from '../../actions/floorSearch'
+import * as statuses from '../../constants/APIStatuses'
+import Loading from '../Messages/Loading'
+import NotFound from '../Messages/NotFound'
+
+class FloorSearch extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = { error: false }
+  }
+
+  componentWillMount () {
+    if (this.props.searchString && this.props.redirect.status === statuses.NOT_FETCHED) {
+      this.props.searchFloorMaps(this.props.searchString)
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    const status = nextProps.redirect.status
+    const slug = nextProps.redirect.slug
+
+    // if we found a floor, redirect to that floor, otherwise error
+    if (status === statuses.SUCCESS && slug) {
+      this.props.history.push(slug + this.props.searchString)
+    } else if (status === statuses.ERROR ||(status === statuses.SUCCESS && !slug)) {
+      this.setState({ error: true })
+    }
+  }
+
+  render () {
+    if (this.state.error) {
+      return <NotFound />
+    }
+    return <Loading />
+  }
+}
+
+export const mapStateToProps = (state, ownProps) => {
+  const { floorSearch } = state
+
+  return {
+    redirect: floorSearch,
+    searchString: ownProps.location.search,
+    history: ownProps.history,
+  }
+}
+
+export const mapDispatchToProps = (dispatch) => {
+  return {
+    searchFloorMaps: (searchString) => dispatch(searchFloorMaps(searchString)),
+  }
+}
+
+FloorSearch.propTypes = {
+  searchString: PropTypes.string,
+  redirect: PropTypes.object,
+  searchFloorMaps: PropTypes.func.isRequired,
+  history: PropTypes.object,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(FloorSearch)

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -17,7 +17,7 @@ const mapStateToProps = (state, ownProps) => {
     ...state,
     search: state.search,
     menus: state.menus,
-    loggedIn: (personal && personal.login && personal.login.token),
+    loggedIn: Boolean(personal && personal.login && personal.login.token),
     loginUrl: (personal && personal.login && personal.login.redirectUrl),
   }
 }

--- a/src/reducers/floorSearch.js
+++ b/src/reducers/floorSearch.js
@@ -1,0 +1,18 @@
+import { FLOOR_SEARCH_REQUEST, FLOOR_SEARCH_RECEIVE } from '../actions/floorSearch'
+import * as statuses from '../constants/APIStatuses'
+
+export default(state = { status: statuses.NOT_FETCHED, slug: undefined }, action) => {
+  switch (action.type) {
+    case FLOOR_SEARCH_REQUEST:
+      return Object.assign({}, state, {
+        status: statuses.FETCHING,
+      })
+    case FLOOR_SEARCH_RECEIVE:
+      return Object.assign({}, state, {
+        status: action.status,
+        slug: action.slug,
+      })
+    default:
+      return state
+  }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -19,6 +19,7 @@ import librarianInfo from './librarians'
 import menuReducer, { hasNavigation } from './menu'
 import chatReducer from './chat'
 import advancedSearch from './advancedSearch'
+import floorSearch from './floorSearch'
 
 import { combineReducers } from 'redux'
 
@@ -43,6 +44,7 @@ const rootReducer = combineReducers({
   menus: menuReducer,
   chat: chatReducer,
   advancedSearch: advancedSearch,
+  floorSearch: floorSearch,
   renderComponents: hasNavigation,
 })
 

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -2680,6 +2680,19 @@ h3:first-child {
   display: block;
 }
 
+.item-data {
+  margin-bottom: 18px;
+}
+
+.item-data p {
+  margin-bottom: 0;
+}
+
+.item-data h2 {
+  font-size: 25px;
+  margin-bottom: 8px;
+}
+
 /* Footer */
 #footer-links {
   background: #595959;

--- a/src/tests/components/Contentful/Floor/index.test.js
+++ b/src/tests/components/Contentful/Floor/index.test.js
@@ -32,6 +32,8 @@ describe('components/Contentful/Floor/Container', () => {
       },
       menus: {},
       location: { search: null },
+      searchParams: new URLSearchParams(),
+      extraData: {},
     }
     enzymeWrapper = setup(props)
   })
@@ -43,7 +45,7 @@ describe('components/Contentful/Floor/Container', () => {
   it('only renders APIPresenterFactory with cfFloorEntry slice and FloorPresenter', () => {
     expect(enzymeWrapper.containsMatchingElement(<APIPresenterFactory
       status={props.cfFloorEntry.status}
-      props={{ cfFloorEntry: props.cfFloorEntry.json }}
+      props={{ cfFloorEntry: props.cfFloorEntry.json, extraData: {} }}
       presenter={FloorPresenter} />))
       .toBe(true)
   })

--- a/src/tests/components/Contentful/Floor/presenter.test.js
+++ b/src/tests/components/Contentful/Floor/presenter.test.js
@@ -4,8 +4,8 @@ import FloorPresenter from '../../../../components/Contentful/Floor/presenter'
 import Building from '../../../../components/Contentful/Building'
 import Image from '../../../../components/Image'
 
-const setup = (cfFloorEntry) => {
-  const props = { cfFloorEntry }
+const setup = (cfFloorEntry, extraData) => {
+  const props = { cfFloorEntry, extraData }
   return shallow(<FloorPresenter {...props} />)
 }
 
@@ -21,6 +21,11 @@ describe('components/Contentful/Floor/presenter', () => {
         building: {},
       },
       sys: { id: 'FakeId' },
+    }, {
+      title: 'itemTitle',
+      call_number: 'call no',
+      author: 'author',
+      collection_display: 'collection'
     })
   })
 
@@ -46,5 +51,13 @@ describe('components/Contentful/Floor/presenter', () => {
 
   it('should render a Building', () => {
     expect(enzymeWrapper.containsMatchingElement(<Building cfBuildingEntry={{}} />)).toBe(true)
+  })
+
+  it('should render the item title', () => {
+    expect(enzymeWrapper.containsMatchingElement(<h2>itemTitle</h2>)).toBe(true)
+  })
+
+  it('should render the item call number', () => {
+    expect(enzymeWrapper.containsMatchingElement(<p>call no</p>)).toBe(true)
   })
 })


### PR DESCRIPTION
Floor search page takes query params and forwards them to the maps api. If a slug is returned from the API, redirect to that floor page.

The `/floor/[slug]` pages now also take query params and display extra information
- title
- author
- call number

This is a basic implementation so we can have it working to demo Wed/Thurs

Relies on https://github.com/ndlib/usurper_content/pull/57