### PR TITLE
LW-406 Address page load speeds of Database A-Z pages on on non-webkit browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-router-config": "^1.0.0-beta.3",
     "react-router-dom": "^4.1.1",
     "react-test-renderer": "^15.5.4",
-    "react-text-ellipsis": "^1.2.2",
+    "react-text-ellipsis": "^1.4.0",
     "redux": "^3.6.0",
     "redux-mock-store": "^1.2.3",
     "redux-thunk": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "react-router-config": "^1.0.0-beta.3",
     "react-router-dom": "^4.1.1",
     "react-test-renderer": "^15.5.4",
-    "react-text-ellipsis": "^1.4.0",
     "redux": "^3.6.0",
     "redux-mock-store": "^1.2.3",
     "redux-thunk": "^2.2.0",

--- a/src/components/DatabaseList/index.js
+++ b/src/components/DatabaseList/index.js
@@ -163,12 +163,33 @@ export class DatabaseListContainer extends Component {
     }, 1500)
   }
 
+  shouldComponentUpdate (nextProps, nextState) {
+    if (this.props.currentLetter !== nextProps.currentLetter) {
+      // letter changed
+      return true
+    } else if (this.props.cfDatabaseLetter[this.props.currentLetter]) {
+      // cfDatabaseLetter is defined
+      if (this.props.cfDatabaseLetter[this.props.currentLetter].status !== nextProps.cfDatabaseLetter[nextProps.currentLetter].status) {
+        // status changed
+        return true
+      }
+      if (this.state.filterValue !== nextState.filterValue) {
+        // filter has changed
+        return true
+      }
+    }
+    return false
+  }
+
   render () {
     let letter = this.props.currentLetter
 
-    // dont allow going to /foo or /1 etc
-    if (letter.length > 1 || ((letter < 'a' || letter > 'z') && letter !== '#')) {
-      return <PageNotFound />
+    // ensure letter exists
+    if (letter) {
+      // dont allow going to /foo or /1 etc
+      if (letter.length > 1 || ((letter < 'a' || letter > 'z') && letter !== '#')) {
+        return <PageNotFound />
+      }
     }
 
     let status = statuses.FETCHING

--- a/src/components/DatabaseList/presenter.js
+++ b/src/components/DatabaseList/presenter.js
@@ -11,7 +11,6 @@ import FilterBox from '../FilterBox'
 import OpenGraph from '../OpenGraph'
 import SideNav from '../SideNav'
 import LibMarkdown from '../LibMarkdown'
-import TextEllipsis from 'react-text-ellipsis'
 import Alphabet from './Alphabet'
 import Loading from '../Messages/Loading'
 import { getLinkObject } from '../../shared/ContentfulLibs'
@@ -86,7 +85,7 @@ const Loaded = (props) => {
           }
         </ul>
         <div className='database-list'>
-          <TextEllipsis lines={3}>{linkObject.heading.description}</TextEllipsis>
+          {linkObject.heading.description}
         </div>
         <Link to={'/database/' + item.sys.id} className='moreinfo'
           ariaLabel={'More Information about ' + item.fields.title}>More info</Link>

--- a/src/components/DatabaseList/presenter.js
+++ b/src/components/DatabaseList/presenter.js
@@ -1,5 +1,5 @@
 // Presenter component for a Page content type from Contentful
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import '../../static/css/global.css'
 import PageTitle from '../PageTitle'
@@ -13,6 +13,7 @@ import SideNav from '../SideNav'
 import LibMarkdown from '../LibMarkdown'
 import TextEllipsis from 'react-text-ellipsis'
 import Alphabet from './Alphabet'
+import Loading from '../Messages/Loading'
 import { getLinkObject } from '../../shared/ContentfulLibs'
 import './style.css'
 
@@ -54,7 +55,8 @@ const Content = (letter, data, filterValue, onFilterChange, assistText) => {
 }
 
 const DBLoading = (letter) => {
-  return Content(letter, 'Loading Databases')
+  return (<Loading />)
+  // return Content(letter, 'Loading Databases')
 }
 
 const Loaded = (props) => {

--- a/src/components/DatabaseList/style.css
+++ b/src/components/DatabaseList/style.css
@@ -9,3 +9,13 @@
     display: inline;
   }
 }
+
+.database-list {
+  width: 100%;
+  word-wrap: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+}

--- a/src/components/OpenGraph/index.js
+++ b/src/components/OpenGraph/index.js
@@ -12,6 +12,7 @@ const OpenGraph = (props) => {
   if (props.image && props.image.fields && props.image.fields.file) {
     image = props.image.fields.file.url
   }
+
   return (
     <Helmet>
       <meta property='og:url' content={url} />
@@ -28,6 +29,6 @@ OpenGraph.propTypes = {
   type: PropTypes.string,
   title: PropTypes.string,
   description: PropTypes.string,
-  image: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ]),
+  image: PropTypes.oneOfType([ PropTypes.string, PropTypes.object, PropTypes.bool ]),
 }
 export default OpenGraph

--- a/src/tests/components/DatabaseList/presenter.test.js
+++ b/src/tests/components/DatabaseList/presenter.test.js
@@ -4,6 +4,7 @@ import '../../../static/css/global.css'
 import ListPresenter from '../../../components/DatabaseList/presenter'
 import Link from '../../../components/Link'
 import ErrorLoading from '../../../components/Messages/Error'
+import Loading from '../../../components/Messages/Loading'
 import * as statuses from '../../../constants/APIStatuses'
 import { shallow } from 'enzyme'
 
@@ -28,18 +29,9 @@ describe('components/DatabaseList/presenter.js', () => {
     afterEach(() => {
       enzymeWrapper = undefined
     })
-
-    it('should have proper page title', () => {
+    it('should show the Loading component', () => {
       expect(enzymeWrapper
-        .containsMatchingElement(<PageTitle title={'Databases: ' + props.letter.toUpperCase()} />))
-        .toBe(true)
-    })
-
-    it('should have proper database list {data}', () => {
-      expect(enzymeWrapper
-        .containsMatchingElement(<section aria-label={'List of all "' + props.letter.toUpperCase() + '" Databases'}>
-          Loading Databases
-        </section>))
+        .containsMatchingElement(<Loading />))
         .toBe(true)
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2427,6 +2427,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
@@ -3872,6 +3884,10 @@ lodash.uniq@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.5:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 log-driver@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
@@ -4871,6 +4887,14 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
@@ -5062,17 +5086,27 @@ react-test-renderer@^15.5.4:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-text-ellipsis@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/react-text-ellipsis/-/react-text-ellipsis-1.2.2.tgz#dda7d4ed22ae7a50b6b6a9eeea2e400cb553cc77"
+react-text-ellipsis@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-text-ellipsis/-/react-text-ellipsis-1.4.0.tgz#14956d8a320d9dd93171d8e87637543ef91a91f0"
   dependencies:
-    lodash "^4.17.4"
-    prop-types "^15.5.10"
-    react "^15.6.1"
+    lodash "^4.17.5"
+    prop-types "^15.6.1"
+    react "^15.6.2"
 
-react@^15.5.4, react@^15.6.1:
+react@^15.5.4:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  dependencies:
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
+
+react@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
     create-react-class "^15.6.0"
     fbjs "^0.8.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2427,18 +2427,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
 fbjs@^0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
@@ -3884,10 +3872,6 @@ lodash.uniq@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-
 log-driver@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
@@ -4887,14 +4871,6 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-prop-types@^15.6.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
@@ -5086,27 +5062,9 @@ react-test-renderer@^15.5.4:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-text-ellipsis@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-text-ellipsis/-/react-text-ellipsis-1.4.0.tgz#14956d8a320d9dd93171d8e87637543ef91a91f0"
-  dependencies:
-    lodash "^4.17.5"
-    prop-types "^15.6.1"
-    react "^15.6.2"
-
 react@^15.5.4:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
-react@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
     create-react-class "^15.6.0"
     fbjs "^0.8.9"


### PR DESCRIPTION
* Added `shouldComponentUpdate` method to the DatabaseList component to reduce number of redundant `render` calls.
* Removed `react-text-ellipsis` component.
* Added `-webkit` CSS to handle ellipsis.
* Added 'Loading' component during FETCHING cycle as UI enhancement.
* Fixed tests to reflect changes in adding 'Loading' component.

**REGRESSION:**
* Ellipsis no longer appear on Microsoft browsers or Firefix (however page load speed is greatly increased)

**NOTE:**
* `react-text-ellipsis` does browser detection on each usage. If webkit was detected, ellipsis was handled with CSS. If a non-webkit browser is detected an event listener is added on each occurrence and the text that is passed as a child is manipulated through javascript.