### PR TITLE
LW-363, LW-392 Google Analytics and Monsido scripts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,7 @@
     <script>
       // Google Tag Manager
       // Analytics implemented through tag 'UA-2118378-47'
+      // HotJar implemented through tag '592165'
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TWL3G7T');
 
       // Monsido

--- a/public/index.html
+++ b/public/index.html
@@ -24,10 +24,8 @@
     <!-- End Google Verification -->
 
     <script>
-      // Google Analytics
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create', 'UA-2118378-47', 'auto');ga('send', 'pageview');
-
       // Google Tag Manager
+      // Analytics implemented through tag 'UA-2118378-47'
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TWL3G7T');
 
       // Hotjar

--- a/public/index.html
+++ b/public/index.html
@@ -28,9 +28,6 @@
       // Analytics implemented through tag 'UA-2118378-47'
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TWL3G7T');
 
-      // Hotjar
-      (function(h,o,t,j,a,r){  h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};h._hjSettings={hjid:592165,hjsv:5};a=o.getElementsByTagName('head')[0];r=o.createElement('script');r.async=1;r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;a.appendChild(r);})(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
-
       // Monsido
       var _monsido = _monsido || [];_monsido.push(['_setDomainToken', 'f9lc1kYwcip6xFgYi51QVQ']);_monsido.push(['_withStatistics', 'true']);
     </script>

--- a/public/index.html
+++ b/public/index.html
@@ -1,30 +1,44 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <title>Hesburgh Library</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-TWL3G7T');</script>
-    <!-- End Google Tag Manager -->
-
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="msapplication-config" content="/icons/browserconfig.xml">
+    <meta name="theme-color" content="#ffffff">
+
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
     <link rel="manifest" href="/icons/manifest.json">
     <link rel="mask-icon" href="/icons/safari-pinned-tab.svg">
     <link rel="shortcut icon" href="/icons/favicon.ico">
-    <meta name="msapplication-config" content="/icons/browserconfig.xml">
-    <meta name="theme-color" content="#ffffff">
-    <meta name="google-site-verification" content="tn6YB8DPKBmVD4GFw8v-nViSCghU-HtdNEaWk4XdXGo" />
-    <meta name="google-site-verification" content="qq7fBdp8zPSI3R9_LFQ4YFmBzTw7Etg5M5HbSgZ_hak" />
-    <meta name="google-site-verification" content="zISdamiilUYTQJfVqU4OSM85zEDAJTcioljTdgbaCxo" />
-    <meta name="google-site-verification" content="df7oJV_ryb0hmj991vCUHHgEkZs4_PxsqKbobpHEp8U" />
-    <title>Hesburgh Library</title>
+
+    <!-- Google Verification -->
+    <meta name="google-site-verification" content="tn6YB8DPKBmVD4GFw8v-nViSCghU-HtdNEaWk4XdXGo" user='hb'/>
+    <meta name="google-site-verification" content="qq7fBdp8zPSI3R9_LFQ4YFmBzTw7Etg5M5HbSgZ_hak" user='rf'/>
+    <meta name="google-site-verification" content="zISdamiilUYTQJfVqU4OSM85zEDAJTcioljTdgbaCxo" user='jh'/>
+    <meta name="google-site-verification" content="df7oJV_ryb0hmj991vCUHHgEkZs4_PxsqKbobpHEp8U" user='rd' />
+    <meta name="google-site-verification" content="kiUlnvDP0sZ96LCd5lRAbBvMxYVje53ppg2omqweX2Q" user='dw'/>
+    <!-- End Google Verification -->
+
+    <script>
+      // Google Analytics
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create', 'UA-2118378-47', 'auto');ga('send', 'pageview');
+
+      // Google Tag Manager
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TWL3G7T');
+
+      // Hotjar
+      (function(h,o,t,j,a,r){  h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};h._hjSettings={hjid:592165,hjsv:5};a=o.getElementsByTagName('head')[0];r=o.createElement('script');r.async=1;r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;a.appendChild(r);})(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
+
+      // Monsido
+      var _monsido = _monsido || [];_monsido.push(['_setDomainToken', 'f9lc1kYwcip6xFgYi51QVQ']);_monsido.push(['_withStatistics', 'true']);
+    </script>
+    <script src="//cdn.monsido.com/tool/javascripts/monsido.js"></script>
+
+    <!-- Structured Data -->
     <script type="application/ld+json">
     {
       "@context": "http://schema.org",
@@ -37,43 +51,18 @@
       }
     }
     </script>
-
-    <!-- Hotjar -->
-    <script>
-    (function(h,o,t,j,a,r){
-      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-      h._hjSettings={hjid:592165,hjsv:5};
-      a=o.getElementsByTagName('head')[0];
-      r=o.createElement('script');r.async=1;
-      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-      a.appendChild(r);
-    })(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
-    </script>
-    <!-- End Hotjar -->
+    <!-- End Structured Data -->
 
   </head>
   <body style="margin: 0;">
+
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe title="" src="https://www.googletagmanager.com/ns.html?id=GTM-TWL3G7T"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-    <div id="root"></div>
-    <noscript>Please enable javascript.</noscript>
-
-    <!-- GA -->
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-2118378-47', 'auto');
-      ga('send', 'pageview');
-    </script>
-    <!-- End GA -->
-
-    <!-- Monsido -->
-    <script type="text/javascript"> var _monsido = _monsido || []; _monsido.push(['_setDomainToken', 'aNJXE_00wyCmVU60UlFO2w']); _monsido.push(['_withStatistics', 'true']); </script> <script src="//cdn.monsido.com/tool/javascripts/monsido.js"></script>
+    <div id="root">
+      <noscript>Please enable javascript.</noscript>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
* Google analytics snippet removed. It has been implemented in Google tag manager.
* Monsido script replaced with one provided in LW-392

**Additional:**
* Reordered some of the items in the index.html
* Removed white space from some scripts
* Add user initials to `google-site-verification` metatags for sanity
* Moved `title` tag to top. (Yes it can go before `X-UA-Compatible`.)
* Moved `<noscript/>` text inside the `root` div.