### PR TITLE
added css cmd to remove from speech

### DIFF
--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -1463,6 +1463,7 @@ label[for='q']:after, .uSearchBox label:after {
   left: 3px;
   position: absolute;
   top: -1px;
+  speak: none;
 }
 
 .menu-drawer a {


### PR DESCRIPTION
THIS DOES NOT WORK!  
This implementation follows the css3 draft but as far as I can tell no browsers implement it.  This is similar to the @media speech directive which also does not work! 

I have added this so that someday in the bright future if browsers ever catch up we can all die knowing that we have finally removed the really really annoying < from the screen reader on the website menus. 

# speak property
https://css-tricks.com/almanac/properties/s/speak/

# state of speak and its relation to aria-hidden. 
https://stackoverflow.com/questions/27751738/is-the-css-setting-speaknone-now-equivalent-to-aria-hidden-true
I have also checked chrome, safari and firefox the screen reader read the text in all cases. 

# more 
I also learned there is a whole set of properties besides speech that in theory let you control the type of voice, speed, and pauses but I expect those are unimplemented as well.  