### PR TITLE
let errored images render so prerender works correctly

### DIFF
--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -68,7 +68,8 @@ export class ImageContainer extends Component {
     }
 
     if (this.state.error) {
-      return null
+      // return null
+      console.log('Image load error')
     }
 
     return <Presenter


### PR DESCRIPTION
I added a console log since this is something we want to add to whatever error logging we have in the future. 