### PR TITLE
Floor maps will stay inside the lines

### DIFF
--- a/src/components/Contentful/Floor/presenter.js
+++ b/src/components/Contentful/Floor/presenter.js
@@ -23,7 +23,7 @@ const FloorPresenter = ({ cfFloorEntry, cfServicePoint, extraData }) => (
             </div>
           )
         }
-        <Image cfImage={cfFloorEntry.fields.image} />
+        <Image cfImage={cfFloorEntry.fields.image} className='floor-map' />
       </div>
       <div className='col-md-4 col-sm-5 col-xs-12 right'>
         <LibMarkdown>{cfFloorEntry.fields.shortDescription}</LibMarkdown>

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -1985,6 +1985,10 @@ address {
   padding-bottom: 18px;
 }
 
+.floor-map {
+  max-width: 100%;
+}
+
 .contact-page .point .fax {
   background-image: url("../images/fax.png");
   padding-top: 15px !important;

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -2796,6 +2796,11 @@ p < img {
 .item-data {
   margin-bottom: 18px;
   line-height: 2em;
+  background-color: white;
+  padding: 11px;
+  -webkit-box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.25);
+  -moz-box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.25);
+  box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.25);
 }
 
 .item-data p {


### PR DESCRIPTION
- Large maps will stay within the column
- Added white frame around information given by onesearch items
<img width="830" alt="screen shot 2018-05-29 at 10 15 39 am" src="https://user-images.githubusercontent.com/22030420/40666340-72fe1cfc-632d-11e8-9f39-370a637cce12.png">
