### PR TITLE
Fix build.js to run in post-deploy

### DIFF
--- a/deploy/web/postDeploy.py
+++ b/deploy/web/postDeploy.py
@@ -17,7 +17,7 @@ def run(stage, outputs):
   scriptutil.executeCommand("cd ../../scripts/build-links && node buildApiUrls.js stage=" + stage)
 
   heslog.info("Building Source")
-  scriptutil.executeCommand("cd ../.. && yarn install --production")
+  scriptutil.executeCommand("cd ../.. && yarn install")
   scriptutil.executeCommand("cd ../.. && yarn build --production")
 
   heslog.info("Deploying code to bucket %s" % bucket)


### PR DESCRIPTION
In order for the command `yarn build --production` to work, we need to include dev dependencies in the `yarn install` command called from postDeploy.py.

The actual built package is not affected by the extra packages since what is build still comes from the production webpack configuration.