### PR TITLE
Add new deploy scripts

### DIFF
--- a/deployDevStaging.sh
+++ b/deployDevStaging.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
+# this is the prebuilt bucket we will target
+export bucketStage="dev"
+
 echo "install build-links modules"
 pushd .
 cd ./scripts/build-links
 yarn install --production
 
 echo "get the apiurls"
-node buildApiUrls.js stage=prep
+node buildApiUrls.js stage=$bucketStage
 echo "determine bucket"
-BUCKET=$(node getStageBucket.js stage=prep)
+BUCKET=$(node getStageBucket.js stage=$bucketStage)
 popd
 
 echo "install npm modules"
@@ -16,5 +19,5 @@ yarn
 echo "build production"
 yarn build --production
 
-echo "Push to bucket"
+echo "Push to bucket, $BUCKET"
 aws s3 sync --delete build/public s3://$BUCKET

--- a/deployServicesLocal.sh
+++ b/deployServicesLocal.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# this is the stage that will appear in aws.
+export stage="dev"
+# this is the set of keys we get from secrets the easy way to think about it
+# is that this separates which version of contentful you want.
+export secretSet="dev"
+# are we updating, creating or deleting
+export deployType="update"
+
+pushd .
+cd ../lambda_auth/deploy/
+source /Volumes/vars/WSE/secret_$secretSet/lambda_auth/deploy-env
+hesdeploy -s $stage --update --yes
+popd
+
+pushd .
+cd ../contentful_direct/deploy/
+source /Volumes/vars/WSE/secret_$secretSet/contentful_direct/deploy-env
+hesdeploy -s $stage --$deployType --yes
+popd .
+
+pushd .
+cd ../contentful_maps/deploy/
+source /Volumes/vars/WSE/secret_$secretSet/contentful_maps/deploy-env
+hesdeploy -s $stage --$deployType --yes
+popd .
+
+pushd .
+cd ../recommendation_engine/deploy/
+source /Volumes/vars/WSE/secret_$secretSet/recommend/deploy-env
+hesdeploy -s $stage --$deployType --yes
+popd .
+
+pushd .
+cd ../monarch_libguides/deploy/
+source /Volumes/vars/WSE/secret_$secretSet/monarch_libguides/deploy-env
+hesdeploy -s $stage --$deployType --yes
+popd .
+
+pushd .
+cd ../gatekeeper/deploy/
+source /Volumes/vars/WSE/secret_$secretSet/gatekeeper/deploy-env
+hesdeploy -s $stage --$deployType --yes
+popd .


### PR DESCRIPTION
It deploys the services and has a script to deploy the website.  

NOTE: this is not a final version of this process but more of a guideline you can look at to see how it should function.  We may wish to use these for now and they give an example of what order things need to be run in but eventually they need to be moved to codeBuild + Jenkins/pipeline.  

Also, the exports are intentional.  I want you to have to look at the file before you run it.  