### PR TITLE
combined previously published and contact us into single markdown box

### DIFF
--- a/src/components/Contentful/News/presenter.js
+++ b/src/components/Contentful/News/presenter.js
@@ -33,14 +33,6 @@ const PagePresenter = ({ entry }) => (
           </div>
         )}
         <ShareLinks className='separator' title={entry.fields.title} />
-        { entry.fields.prevPublishedUrl && (
-          <div className='prevPubDate'>
-            Previously Published&nbsp;
-            <Link to={entry.fields.prevPublishedUrl}>
-              { entry.fields.prevPublishedUrl }
-            </Link>
-          </div>
-        )}
       </div>
     </PageTitle>
     <OpenGraph
@@ -53,7 +45,7 @@ const PagePresenter = ({ entry }) => (
       <main className='col-md-8 col-sm-8 article'>
         <Image cfImage={entry.fields.image} className='news cover' itemProp='image' />
         <LibMarkdown itemProp='articleBody'>{ entry.fields.content }</LibMarkdown>
-        <LibMarkdown >{ entry.fields.articleContacts }</LibMarkdown>
+        <LibMarkdown >{ entry.fields.contactUsPubInfo }</LibMarkdown>
         <Related className='p-resources' title='Resources' showImages={false}>{ entry.fields.relatedResources }</Related>
         <Link to='/news' className='newsEventsLink viewAll'>View All News</Link>
       </main>

--- a/src/components/Contentful/News/style.css
+++ b/src/components/Contentful/News/style.css
@@ -1,4 +1,0 @@
-.prevPubDate {
-    margin-top: 7px;
-    text-transform: none;
-}


### PR DESCRIPTION
On News items previously published text was at the top of the page and contact us was contained within the news article body markdown.  The previously published text and contact us info have been combined into their own markdown box and put immediately after the article body.
<img width="491" alt="screen shot 2018-09-27 at 9 15 00 am" src="https://user-images.githubusercontent.com/34040873/46149824-21c0ad80-c239-11e8-83d3-2518a535f9ec.png">
