### PR TITLE
LW-537 Improve Search Box Responsiveness

### DIFF
--- a/src/components/SearchDrawer/AdvancedSearch/AdvancedSearchField/SearchInput/index.js
+++ b/src/components/SearchDrawer/AdvancedSearch/AdvancedSearchField/SearchInput/index.js
@@ -11,8 +11,14 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onChange: (e) => {
+    onBlur: (e) => {
       dispatch(setSearchOption(e.target.id, e.target.value))
+    },
+    onKeyDown: (e) => {
+      // Enter
+      if (e.keyCode === 13) {
+        dispatch(setSearchOption(e.target.id, e.target.value))
+      }
     },
   }
 }

--- a/src/components/SearchDrawer/AdvancedSearch/AdvancedSearchField/SearchInput/presenter.js
+++ b/src/components/SearchDrawer/AdvancedSearch/AdvancedSearchField/SearchInput/presenter.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const SearchInput = (props) => {
-  return (<input id={props.id} onChange={props.onChange} />)
+  return (<input id={props.id} onBlur={props.onBlur} onKeyDown={props.onKeyDown} />)
 }
 
 export default SearchInput

--- a/src/components/SearchDrawer/AdvancedSearch/AdvancedSearchField/SearchInput/presenter.js
+++ b/src/components/SearchDrawer/AdvancedSearch/AdvancedSearchField/SearchInput/presenter.js
@@ -5,4 +5,10 @@ const SearchInput = (props) => {
   return (<input id={props.id} onBlur={props.onBlur} onKeyDown={props.onKeyDown} />)
 }
 
+SearchInput.propTypes = {
+  id: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
+  onKeyDown: PropTypes.func,
+}
+
 export default SearchInput

--- a/src/components/SearchDrawer/AdvancedSearch/DateField/index.js
+++ b/src/components/SearchDrawer/AdvancedSearch/DateField/index.js
@@ -21,6 +21,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     onChange: (e) => {
       dispatch(setSearchOption(e.target.id, e.target.value))
     },
+    onKeyDown: (e) => {
+      // Enter
+      if (e.keyCode === 13) {
+        dispatch(setSearchOption(e.target.id, e.target.value))
+      }
+    },
     formatID: (n, p) => {
       return `${p}_${padZero(n)}`
     },

--- a/src/components/SearchDrawer/AdvancedSearch/DateField/presenter.js
+++ b/src/components/SearchDrawer/AdvancedSearch/DateField/presenter.js
@@ -27,7 +27,13 @@ const DateField = (props) => {
         <span className='selector'><select id={`${props.id}Month`} onChange={props.onChange}>
           {months}
         </select></span>
-        <input type='text' id={`${props.id}Year5`} placeholder='year' onChange={props.onChange} />
+        <input
+          type='text'
+          id={`${props.id}Year5`}
+          placeholder='year'
+          onBlur={props.onChange}
+          onKeyDown={props.onKeyDown}
+        />
       </div>
     </div>
   )

--- a/src/components/SearchDrawer/AdvancedSearch/DateField/presenter.js
+++ b/src/components/SearchDrawer/AdvancedSearch/DateField/presenter.js
@@ -39,4 +39,10 @@ const DateField = (props) => {
   )
 }
 
+DateField.propTypes = {
+  id: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  onKeyDown: PropTypes.func,
+}
+
 export default DateField

--- a/src/components/SearchDrawer/SearchBox/index.js
+++ b/src/components/SearchDrawer/SearchBox/index.js
@@ -59,6 +59,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       }
     },
     inputOnKeyDown: (e) => {
+      // Enter
       if (e.keyCode === 13) {
         dispatch(setSearchOption(e.target.id, e.target.value))
       }

--- a/src/components/SearchDrawer/SearchBox/index.js
+++ b/src/components/SearchDrawer/SearchBox/index.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router'
 import { openSearchBox, closeSearchBox } from '../../../actions/search.js'
 import { setSearchOption } from '../../../actions/advancedSearch.js'
 import searchQuery from '../searchQueryBuilder'
-import SearchBox from './presenter'
+import Presenter from './presenter'
 import ReactGA from 'react-ga'
 import Config from '../../../shared/Configuration'
 import QueryString from 'querystring'
@@ -15,17 +15,60 @@ ReactGA.initialize(Config.googleAnalyticsId, {
   gaOptions: {},
 })
 
-const mapStateToProps = (state, ownProps) => {
-  return {
-    onSubmit: (e) => {
-      e.preventDefault()
+class SearchBox extends React.Component {
+  constructor (props) {
+    super(props)
+    this.onSubmit = this.onSubmit.bind(this)
+    this.onChange = this.onChange.bind(this)
+  }
+
+  componentDidMount () {
+    this.setState({
+      searchId: 'basic-search-field',
+      searchValue: this.props.defaultSearch,
+      submitSearch: false,
+    })
+  }
+
+  componentDidUpdate (prevProps, prevState) {
+    if (this.state.submitSearch && !prevState.submitSearch) {
       ReactGA.event({
         category: `LIBRARY WEBSITE SEARCH SUBMISSION`,
-        action: `${state.search.searchType}`,
-        label: `${state.advancedSearch['basic-search-field']}`,
+        action: `${this.props.search.searchType}`,
+        label: `${this.props.advancedSearch['basic-search-field']}`,
       })
-      searchQuery(state.search, state.advancedSearch, ownProps.history)
-    },
+      searchQuery(this.props.search, this.props.advancedSearch, this.props.history)
+
+      this.setState({
+        submitSearch: false,
+      })
+    }
+  }
+
+  onSubmit (e) {
+    e.preventDefault()
+    this.props.dispatch(setSearchOption(this.state.searchId, this.state.searchValue))
+    this.setState({
+      submitSearch: true,
+    })
+  }
+
+  onChange (e) {
+    this.setState({
+      searchId: e.target.id,
+      searchValue: e.target.value,
+    })
+  }
+
+  render () {
+    return (
+      <Presenter onSubmit={this.onSubmit} onChange={this.onChange} {...this.props} />
+    )
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  return {
     ...state,
   }
 }
@@ -43,6 +86,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const qs = QueryString.parse(ownProps.location.search.replace('?', ''))
 
   return {
+    dispatch: dispatch,
     defaultSearch: qs.q,
     onClick:(e) => {
       toggle(e)
@@ -58,10 +102,9 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         setTimeout(() => { document.getElementById('uSearchOption_0').focus() }, 50)
       }
     },
-    onChange: (e) => {
+    onBlur: (e) => {
       dispatch(setSearchOption(e.target.id, e.target.value))
     },
-
   }
 }
 export default withRouter(connect(

--- a/src/components/SearchDrawer/SearchBox/presenter.js
+++ b/src/components/SearchDrawer/SearchBox/presenter.js
@@ -42,6 +42,7 @@ const SearchBox = (props) => {
           name='q'
           defaultValue={props.defaultSearch}
           onChange={props.onChange}
+          onBlur={props.onBlur}
           aria-labelledby='label-for-basic-search-field' />
       </div>
       <button onClick={props.onSubmit}>Search</button>
@@ -54,7 +55,7 @@ SearchBox.propTypes = {
   defaultSearch: PropTypes.string,
   onClick: PropTypes.func,
   onKeyDown: PropTypes.func,
-  onChange: PropTypes.func,
+  onBlur: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
   search: PropTypes.shape({
     searchBoxOpen: PropTypes.bool,

--- a/src/components/SearchDrawer/SearchBox/presenter.js
+++ b/src/components/SearchDrawer/SearchBox/presenter.js
@@ -17,7 +17,7 @@ const SearchBox = (props) => {
           <li
             id='selected-search'
             onClick={props.onClick}
-            onKeyDown={props.onKeyDown}
+            onKeyDown={props.dropdownOnKeyDown}
             tabIndex='0'>
             <span
               className='screen-reader-only'
@@ -34,16 +34,16 @@ const SearchBox = (props) => {
       <div className='input'>
         <span
           className='screen-reader-only'
-          id='label-for-basic-search-field'
+          id={`label-for-${props.id}`}
         >Search in { props.currentSearch.title }</span>
         <input
-          id='basic-search-field'
+          id={props.id}
           role='searchbox'
           name='q'
           defaultValue={props.defaultSearch}
-          onChange={props.onChange}
           onBlur={props.onBlur}
-          aria-labelledby='label-for-basic-search-field' />
+          onKeyDown={props.inputOnKeyDown}
+          aria-labelledby={`label-for-${props.id}`} />
       </div>
       <button onClick={props.onSubmit}>Search</button>
     </span>
@@ -54,13 +54,15 @@ SearchBox.propTypes = {
   currentSearch: PropTypes.object.isRequired,
   defaultSearch: PropTypes.string,
   onClick: PropTypes.func,
-  onKeyDown: PropTypes.func,
+  dropdownOnKeyDown: PropTypes.func,
+  inputOnKeyDown: PropTypes.func,
   onBlur: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
   search: PropTypes.shape({
     searchBoxOpen: PropTypes.bool,
   }),
   visible: PropTypes.bool,
+  id: PropTypes.string.isRequired,
 }
 
 export default SearchBox

--- a/src/components/SearchDrawer/presenter.js
+++ b/src/components/SearchDrawer/presenter.js
@@ -18,6 +18,7 @@ const Drawer = (props) => {
             visible={!props.search.advancedSearch}
             {...props}
             currentSearch={props.currentSearch}
+            id='basic-search-field'
           />
           <AdvancedSearch visible={props.search.advancedSearch} />
           <SearchPreference


### PR DESCRIPTION
Input fields in search boxes are slow to respond because they are updating the store on every key press. These changes only update the store when the element loses focus (onBlur) or when the form is submitted without changing focus. (onKeyDown enter)

Applies to both basic search and advanced search.