### PR TITLE
Fix response validation coming from contentful direct.

### DIFF
--- a/src/actions/contentful/allAlerts.js
+++ b/src/actions/contentful/allAlerts.js
@@ -26,7 +26,7 @@ const receiveAllAlerts = (response) => {
   }
 
   try {
-    if (response[0] && response[0].sys.id) {
+    if (Array.isArray(response)) {
       return success
     } else {
       return error

--- a/src/actions/contentful/allAlerts.js
+++ b/src/actions/contentful/allAlerts.js
@@ -26,7 +26,7 @@ const receiveAllAlerts = (response) => {
   }
 
   try {
-    if (response) {
+    if (response[0] && response[0].sys.id) {
       return success
     } else {
       return error

--- a/src/actions/contentful/allEvents.js
+++ b/src/actions/contentful/allEvents.js
@@ -26,7 +26,7 @@ const receiveAllEvents = (response) => {
   }
 
   try {
-    if (response[0] && response[0].sys.id) {
+    if (Array.isArray(response)) {
       return success
     } else {
       return error

--- a/src/actions/contentful/allEvents.js
+++ b/src/actions/contentful/allEvents.js
@@ -26,7 +26,7 @@ const receiveAllEvents = (response) => {
   }
 
   try {
-    if (response) {
+    if (response[0] && response[0].sys.id) {
       return success
     } else {
       return error

--- a/src/actions/contentful/allNews.js
+++ b/src/actions/contentful/allNews.js
@@ -26,7 +26,7 @@ const receiveAllNews = (response) => {
   }
 
   try {
-    if (response) {
+    if (response[0] && response[0].sys.id) {
       return success
     } else {
       return error

--- a/src/actions/contentful/allNews.js
+++ b/src/actions/contentful/allNews.js
@@ -26,7 +26,7 @@ const receiveAllNews = (response) => {
   }
 
   try {
-    if (response[0] && response[0].sys.id) {
+    if (Array.isArray(response)) {
       return success
     } else {
       return error

--- a/src/actions/contentful/databaseLetter.js
+++ b/src/actions/contentful/databaseLetter.js
@@ -31,7 +31,7 @@ const receiveLetter = (letter, response) => {
   }
 
   try {
-    if (response[0] && response[0].sys.id) {
+    if (Array.isArray(response)) {
       return success(response)
     } else {
       return error

--- a/src/actions/contentful/databaseLetter.js
+++ b/src/actions/contentful/databaseLetter.js
@@ -31,7 +31,7 @@ const receiveLetter = (letter, response) => {
   }
 
   try {
-    if (response) {
+    if (response[0] && response[0].sys.id) {
       return success(response)
     } else {
       return error

--- a/src/actions/contentful/entry.js
+++ b/src/actions/contentful/entry.js
@@ -23,13 +23,13 @@ const receiveEntry = (entry, response) => {
   let success = {
     type: CF_RECEIVE_ENTRY,
     status: statuses.SUCCESS,
-    page: response,
+    page: response[0],
     receivedAt: Date.now(),
     entry,
   }
 
   try {
-    if (response.sys.id) {
+    if (response[0] && response[0].sys.id) {
       return success
     } else {
       return error
@@ -71,7 +71,7 @@ export const fetchEntry = (id, slug, preview) => {
         }
       })
       .then(json => {
-        dispatch(receiveEntry(entryIdent, json[0]))
+        dispatch(receiveEntry(entryIdent, json))
       })
       .catch(response => dispatch(
         receiveEntry(entryIdent, response)))

--- a/src/actions/contentful/event.js
+++ b/src/actions/contentful/event.js
@@ -27,7 +27,7 @@ const receiveEvent = (event, response) => {
   }
 
   try {
-    if (response[0].sys.contentType.sys.id === 'event') {
+    if (response[0] && response[0].sys.contentType.sys.id === 'event') {
       return success
     } else {
       console.log(response)

--- a/src/actions/contentful/floor.js
+++ b/src/actions/contentful/floor.js
@@ -27,7 +27,7 @@ const receiveFloor = (floor, response) => {
   }
 
   try {
-    if (response[0].sys.contentType.sys.id === 'floor') {
+    if (response[0] && response[0].sys.contentType.sys.id === 'floor') {
       return success
     } else {
       return error

--- a/src/actions/contentful/news.js
+++ b/src/actions/contentful/news.js
@@ -27,7 +27,7 @@ const receiveNews = (news, response) => {
   }
 
   try {
-    if (response[0].sys.contentType.sys.id === 'news') {
+    if (response[0] && response[0].sys.contentType.sys.id === 'news') {
       return success
     } else {
       return error

--- a/src/actions/contentful/page.js
+++ b/src/actions/contentful/page.js
@@ -14,7 +14,7 @@ export const CF_RECEIVE_PAGE = 'CF_RECEIVE_PAGE'
 const receiveError = (page, response) => {
   return {
     type: CF_RECEIVE_PAGE,
-    status: statuses.fromHttpStatusCode(response.status),
+    status: statuses.fromHttpStatusCode(response ? response.status : null),
     error: response,
     slug: page,
     receivedAt: Date.now(),
@@ -34,7 +34,8 @@ const receivePage = (page, response) => {
   if (Array.isArray(response)) {
     response = response[0]
   }
-  if (response.sys &&
+  if (response &&
+      response.sys &&
       response.sys.contentType &&
       response.sys.contentType.sys &&
       (response.sys.contentType.sys.id === 'page' || response.sys.contentType.sys.id === 'columnContainer')) {

--- a/src/actions/contentful/servicePoints.js
+++ b/src/actions/contentful/servicePoints.js
@@ -26,7 +26,7 @@ const receiveServicePoints = (response) => {
   }
 
   try {
-    if (response[0] && response[0].sys.id) {
+    if (Array.isArray(response)) {
       return success
     } else {
       return error

--- a/src/actions/contentful/servicePoints.js
+++ b/src/actions/contentful/servicePoints.js
@@ -26,7 +26,7 @@ const receiveServicePoints = (response) => {
   }
 
   try {
-    if (response) {
+    if (response[0] && response[0].sys.id) {
       return success
     } else {
       return error

--- a/src/actions/contentful/staticContent.js
+++ b/src/actions/contentful/staticContent.js
@@ -29,7 +29,7 @@ const receiveSidebar = (slug, response) => {
   }
 
   try {
-    if (response[0].sys.contentType.sys.id === 'dynamicPage') {
+    if (response[0] && response[0].sys.contentType.sys.id === 'dynamicPage') {
       return success
     } else {
       return error


### PR DESCRIPTION
We are supposed to be catching errors when fetching from contentful direct and piping the result into an error object, which has a different schema compared to the success object. However, we were frequently only checking for the existence of a response to determine whether there was a success or not, so errors were incorrectly getting marked as "statuses.SUCCESS" and subsequently causing rendering errors since the schema did not match.