### PR TITLE
LW-567 Add ability to switch search type in advanced search.

### DIFF
--- a/src/components/SearchDrawer/AdditionalLinks/index.js
+++ b/src/components/SearchDrawer/AdditionalLinks/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import searchOptions, { ONESEARCH, NDCATALOG } from '../searchOptions'
+import { searchOptions } from '../../../constants/searchOptions'
 
 const AdditionalLinks = (props) => {
   let links = []
   let key = 0
-  if (props.currentSearch.uid === ONESEARCH || props.currentSearch.uid === NDCATALOG) {
+  let opt = searchOptions.find((el) => { return el.uid === props.currentSearch.uid })
+  if (opt && opt.enableAdvancedSearch) {
     links.push(
       <a
         onClick={props.toggleAdvancedSearch}
@@ -25,6 +26,12 @@ const AdditionalLinks = (props) => {
 
   return (
     <div className='additional-links'>{links}</div>)
+}
+
+AdditionalLinks.propTypes = {
+  toggleAdvancedSearch: PropTypes.func,
+  advancedButtonLabel: PropTypes.string,
+  currentSearch: PropTypes.object,
 }
 
 export default AdditionalLinks

--- a/src/components/SearchDrawer/AdvancedSearch/index.js
+++ b/src/components/SearchDrawer/AdvancedSearch/index.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import AdvancedSearch from './presenter'
 import searchQuery from '../searchQueryBuilder'
+import { setSearchType } from '../../../actions/search.js'
 import './style.css'
+
 const mapStateToProps = (state, ownProps) => {
   return {
     ...state,
@@ -11,7 +13,11 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  return {}
+  return {
+    dropdownOnChange: (e) => {
+      dispatch(setSearchType(e.target.value))
+    },
+  }
 }
 
 const mergeProps = (state, dispatch, ownProps) => {

--- a/src/components/SearchDrawer/AdvancedSearch/presenter.js
+++ b/src/components/SearchDrawer/AdvancedSearch/presenter.js
@@ -1,43 +1,73 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import AdvancedSearchTitle from './AdvancedSearchTitle'
 import AdvancedSearchField from './AdvancedSearchField'
 import Bool from './Bool'
 import MaterialType from './MaterialType'
 import Language from './Language'
 import DateField from './DateField'
 import SearchScope from './SearchScope'
+import { searchOptions } from '../../../constants/searchOptions'
 
 const AdvancedSearch = (props) => {
-  if (props.visible) {
+  if (!props.visible) {
+    return null
+  }
+
+  const searchTypeDropdown = () => {
+    let optArray = []
+    for (let i = 0; i < searchOptions.length; i++) {
+      let opt = searchOptions[i]
+      optArray.push(<option key={opt.uid} value={opt.uid}>{opt.title}</option>)
+    }
     return (
-      <div>
-        <AdvancedSearchTitle searchType={props.search.searchType} />
-        <div id='advanced-search'>
-          <div className='asleft'>
-            <AdvancedSearchField id={0} />
-            <Bool id='bool_0' />
-            <AdvancedSearchField id={1} />
-            <Bool id='bool_1' />
-            <AdvancedSearchField id={2} />
-          </div>
-          <div className='asright'>
-            <fieldset>
-              <MaterialType searchType={props.search.searchType} />
-              <Language />
-              <DateField id='drStart' label='Start Date' />
-              <DateField id='drEnd' label='End Date' />
-            </fieldset>
-            <SearchScope searchType={props.search.searchType} />
-          </div>
-          <div className='asgo'>
-            <button onClick={props.onSubmit}>Search</button>
-          </div>
-        </div>
-      </div>
+      <span className='selector'>
+        <select id='advancedSearchType' defaultValue={props.search.searchType} onChange={props.dropdownOnChange}>
+          {optArray}
+        </select>
+      </span>
     )
   }
-  return null
+
+  return (
+    <div>
+      <div id='advanced-search'>
+        <div className='asleft'>
+          <fieldset id={`exlidAdvancedSearchFieldsetDropdown`} >
+            <div className='fgrid'>
+              {searchTypeDropdown(props)}
+            </div>
+          </fieldset>
+          <span className='filler' />
+          <AdvancedSearchField id={0} />
+          <Bool id='bool_0' />
+          <AdvancedSearchField id={1} />
+          <Bool id='bool_1' />
+          <AdvancedSearchField id={2} />
+        </div>
+        <div className='asright'>
+          <fieldset>
+            <MaterialType searchType={props.search.searchType} />
+            <Language />
+            <DateField id='drStart' label='Start Date' />
+            <DateField id='drEnd' label='End Date' />
+          </fieldset>
+          <SearchScope searchType={props.search.searchType} />
+        </div>
+        <div className='asgo'>
+          <button onClick={props.onSubmit}>Search</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+AdvancedSearch.propTypes = {
+  search: PropTypes.shape({
+    searchType: PropTypes.string.isRequired,
+  }),
+  dropdownOnChange: PropTypes.func,
+  onSubmit: PropTypes.func,
+  visible: PropTypes.bool,
 }
 
 export default AdvancedSearch

--- a/src/components/SearchDrawer/AdvancedSearch/style.css
+++ b/src/components/SearchDrawer/AdvancedSearch/style.css
@@ -69,7 +69,7 @@ fieldset {
 	display: grid;
 	grid-template-columns: 1fr 64px;
 	padding-right: 3em;
-	grid-template-rows: 40px 40px;
+	grid-template-rows: 40px 40px 40px 40px;
 	height: auto;
 
 }
@@ -96,7 +96,7 @@ fieldset {
 	width: 100%;
 }
 
-#advanced-search .asleft  .selector::after { 
+#advanced-search .asleft  .selector::after {
 	top: 10px !important;
 	right: 10px;
 }

--- a/src/components/SearchDrawer/SearchOptionList/index.js
+++ b/src/components/SearchDrawer/SearchOptionList/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import SearchOption from './SearchOption'
-import { searchOptions } from '../searchOptions.js'
+import { searchOptions } from '../../../constants/searchOptions.js'
 
 const SearchOptionList = (props) => {
   const classes = props.search.searchBoxOpen ? 'uSearchOptionList' : 'uSearchOptionList hidden'

--- a/src/components/SearchDrawer/index.js
+++ b/src/components/SearchDrawer/index.js
@@ -1,7 +1,7 @@
 'use strict'
 import { connect } from 'react-redux'
 import SearchDrawer from './presenter.js'
-import { searchOptions } from './searchOptions.js'
+import { searchOptions } from '../../constants/searchOptions.js'
 import { openAdvancedSearch, closeAdvancedSearch } from '../../actions/search'
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/components/SearchDrawer/searchQueryBuilder.js
+++ b/src/components/SearchDrawer/searchQueryBuilder.js
@@ -1,4 +1,4 @@
-import { ONESEARCH, NDCATALOG, CURATEND, LIBRARY } from './searchOptions'
+import { ONESEARCH, NDCATALOG, CURATEND, LIBRARY } from '../../constants/searchOptions'
 
 const padLeftZero = (num) => {
   if (num.length < 2) {

--- a/src/constants/searchOptions.js
+++ b/src/constants/searchOptions.js
@@ -10,23 +10,27 @@ export const searchOptions = [
     uid: ONESEARCH,
     title: 'OneSearch',
     description:'The ND Catalog plus articles, datasets and more',
+    enableAdvancedSearch: true,
   },
   {
     uid: NDCATALOG,
     title: 'ND Catalog',
     description:'Print and electronic books, journals and databases',
     additionalLinks: (<a href='https://alephprod.library.nd.edu/F/?func=find-b-0'>Catalog Classic</a>),
+    enableAdvancedSearch: true,
   },
   {
     uid: CURATEND,
     title: 'CurateND',
     description:'Theses, dissertations, articles, and data by ND Researchers',
     additionalLinks: '\u00a0',
+    enableAdvancedSearch: false,
   },
   {
     uid: LIBRARY,
     title: 'Library Website',
     description:'Research guides, services, people and places',
     additionalLinks: '\u00a0',
+    enableAdvancedSearch: false,
   },
 ]

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -13,6 +13,7 @@ import {
 } from '../actions/search.js'
 import { CF_RECEIVE_PAGE } from '../actions/contentful/page'
 import * as statuses from '../constants/APIStatuses'
+import { searchOptions } from '../constants/searchOptions'
 
 let localSearchPref
 let localStorageIsAvailable = false
@@ -67,10 +68,11 @@ export default (
   action
 ) => {
   switch (action.type) {
-    case SET_SEARCH:
-    {
+    case SET_SEARCH: {
+      const newOption = searchOptions.find((el) => { return el.uid === action.searchType })
       let newState = Object.assign({}, state, {
         sessionPref: action.searchType,
+        advancedSearch: (newOption && newOption.enableAdvancedSearch) ? state.advancedSearch : false,
       })
       setSearchType(newState)
       return newState


### PR DESCRIPTION
- Move searchOptions to constants where it fits in better.
- Add "enableAdvancedSearch" to searchOptions array instead of hard-coding a check on individual pages.