### PR TITLE
LW-594 Reduce include depth when fetching from contentful.

### DIFF
--- a/src/actions/contentful/allEvents.js
+++ b/src/actions/contentful/allEvents.js
@@ -37,7 +37,7 @@ const receiveAllEvents = (response) => {
 }
 
 export const fetchAllEvents = (status) => {
-  const query = encodeURIComponent('content_type=event&include=5')
+  const query = encodeURIComponent('content_type=event&include=3')
   const preview = status === 'preview'
   let url = `${Config.contentfulAPI}query?locale=en-US&query=${query}`
   if (preview) { url += `&preview=${preview}` }

--- a/src/actions/contentful/allNews.js
+++ b/src/actions/contentful/allNews.js
@@ -37,7 +37,7 @@ const receiveAllNews = (response) => {
 }
 
 export const fetchAllNews = (preview) => {
-  const query = encodeURIComponent('content_type=news&include=5')
+  const query = encodeURIComponent('content_type=news&include=3')
   let url = `${Config.contentfulAPI}query?locale=en-US&query=${query}`
   if (preview) { url += `&preview=${preview}` }
 

--- a/src/actions/contentful/entry.js
+++ b/src/actions/contentful/entry.js
@@ -51,7 +51,7 @@ export const fetchEntry = (id, slug, preview) => {
   }
   */
   if (id) {
-    identifierParam = encodeURIComponent(`sys.id=${id}&include=5`)
+    identifierParam = encodeURIComponent(`sys.id=${id}&include=3`)
     entryIdent = id
   }
   let url = `${Config.contentfulAPI}query?locale=en-US&query=${identifierParam}`

--- a/src/actions/contentful/event.js
+++ b/src/actions/contentful/event.js
@@ -40,7 +40,7 @@ const receiveEvent = (event, response) => {
 }
 
 export const fetchEvent = (event, preview) => {
-  const query = encodeURIComponent(`content_type=event&fields.slug=${event}&include=5`)
+  const query = encodeURIComponent(`content_type=event&fields.slug=${event}&include=3`)
   let url = `${Config.contentfulAPI}query?locale=en-US&query=${query}`
   if (preview) { url += `&preview=${preview}` }
 

--- a/src/actions/contentful/news.js
+++ b/src/actions/contentful/news.js
@@ -38,7 +38,7 @@ const receiveNews = (news, response) => {
 }
 
 export const fetchNews = (news, preview) => {
-  const query = encodeURIComponent(`content_type=news&fields.slug=${news}&include=5`)
+  const query = encodeURIComponent(`content_type=news&fields.slug=${news}&include=3`)
   let url = `${Config.contentfulAPI}query?locale=en-US&query=${query}`
   if (preview) { url += `&preview=${preview}` }
 

--- a/src/actions/contentful/servicePoints.js
+++ b/src/actions/contentful/servicePoints.js
@@ -37,7 +37,7 @@ const receiveServicePoints = (response) => {
 }
 
 export const fetchServicePoints = (preview, id) => {
-  let query = encodeURIComponent(`content_type=servicePoint&include=5`)
+  let query = encodeURIComponent(`content_type=servicePoint&include=3`)
   if (id) {
     query += encodeURIComponent(`&sys.id=${id}`)
   }

--- a/src/actions/contentful/staticContent.js
+++ b/src/actions/contentful/staticContent.js
@@ -40,7 +40,7 @@ const receiveSidebar = (slug, response) => {
 }
 
 export const fetchSidebar = (slug, preview) => {
-  const query = encodeURIComponent(`content_type=dynamicPage&fields.slug=${slug}&include=5`)
+  const query = encodeURIComponent(`content_type=dynamicPage&fields.slug=${slug}&include=3`)
   let url = `${Config.contentfulAPI}query?locale=en-US&query=${query}`
   if (preview) { url += `&preview=${preview}` }
 

--- a/src/actions/menu.js
+++ b/src/actions/menu.js
@@ -54,7 +54,7 @@ const receiveNavigation = (response) => {
 }
 
 export const fetchNavigation = (preview) => {
-  const query = encodeURIComponent('content_type=columnContainer&fields.slug=navigation&include=5')
+  const query = encodeURIComponent('content_type=columnContainer&fields.slug=navigation&include=4')
   let url = `${Config.contentfulAPI}query?locale=en-US&preview=false&query=${query}`
   return (dispatch) => {
     dispatch(requestNavigation())


### PR DESCRIPTION
Previously fixed on the "page" content type, but I missed the other content types which also specify an include depth.

This can help dramatically reduce the response size and thus improve performance. In the future, we should be very intentional about how deep a certain content type should go and never fetch more than we need.