### PR TITLE
LW-657 Add modal with all subjects (modify favorites using wizard)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-redux": "^7.0.2",
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",
+    "react-tooltip": "^3.10.0",
     "redux": "^4.0.1",
     "redux-mock-store": "^1.5.3",
     "redux-thunk": "^2.3.0",

--- a/src/actions/personal/favorites.js
+++ b/src/actions/personal/favorites.js
@@ -204,6 +204,7 @@ const convertSubjectToFavorite = (subject) => {
       ? typy(subject, 'fields.page.fields.title').safeString
       : typy(subject, 'fields.title').safeString,
     url: '/' + typy(subject, 'fields.page.fields.slug').safeString,
+    order: subject.order,
   }
 }
 
@@ -242,7 +243,7 @@ export const searchFavorites = (kind, searchText) => {
     if (kind === KIND.databases) {
       url += encodeURIComponent(`content_type=resource&include=0&fields.title[match]=${searchText}`)
     } else if (kind === KIND.subjects) {
-      url += encodeURIComponent(`content_type=internalLink&fields.context=Subject&include=1`)
+      url += encodeURIComponent(`content_type=internalLink&fields.context=Subject&include=2`)
     }
 
     return fetch(url)

--- a/src/components/Account/Favorites/ManageFavorites/index.js
+++ b/src/components/Account/Favorites/ManageFavorites/index.js
@@ -84,10 +84,6 @@ export class ManageFavoritesContainer extends Component {
   }
 
   openWizard () {
-    if (this.props.saveState === statuses.FETCHING) {
-      return
-    }
-
     if (this.state.modified) {
       alert('Please save your changes first.')
       return
@@ -139,7 +135,7 @@ export class ManageFavoritesContainer extends Component {
           openWizard={this.openWizard}
         />
         { this.state.wizardOpen && (
-          <Wizard closeCallback={this.closeWizard} stepList={[KIND.subjects]} />
+          <Wizard closeCallback={this.closeWizard} stepList={[this.props.kind]} />
         )}
       </React.Fragment>
     )

--- a/src/components/Account/Favorites/ManageFavorites/presenter.js
+++ b/src/components/Account/Favorites/ManageFavorites/presenter.js
@@ -8,6 +8,7 @@ import FavoritesList from '../FavoritesList'
 import Search from '../Search'
 
 import * as states from 'constants/APIStatuses'
+import { KIND } from 'actions/personal/favorites'
 
 const ManageFavorites = (props) => {
   const saving = props.saveState === states.FETCHING
@@ -25,6 +26,9 @@ const ManageFavorites = (props) => {
           </div>
         </div>
         <button type='submit' className='right' aria-label='Save' disabled={!props.modified || saving} onClick={props.onSave}>Save</button>
+        { props.kind === KIND.subjects && (
+          <button className='right' onClick={props.openWizard} disabled={saving}>View All Subjects</button>
+        )}
         { saving ? (
           <InlineLoading title='Saving...' className='fright pad-edges-sm' />
         ) : (
@@ -46,6 +50,7 @@ ManageFavorites.propTypes = {
   updateList: PropTypes.func,
   onAddFavorite: PropTypes.func,
   onSave: PropTypes.func,
+  openWizard: PropTypes.func,
 }
 
 export default ManageFavorites

--- a/src/components/Account/Favorites/Wizard/SubjectStep/index.js
+++ b/src/components/Account/Favorites/Wizard/SubjectStep/index.js
@@ -36,7 +36,7 @@ class SubjectStep extends Component {
   }
 
   onCheckboxChanged (event) {
-    if (!event.target) {
+    if (typy(event, 'target').isFalsy) {
       return
     }
 

--- a/src/components/Account/Favorites/Wizard/SubjectStep/index.js
+++ b/src/components/Account/Favorites/Wizard/SubjectStep/index.js
@@ -1,18 +1,29 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import ReactTooltip from 'react-tooltip'
+import typy from 'typy'
 
 import Footer from '../Footer'
+
+import * as helper from 'constants/HelperFunctions'
 
 class SubjectStep extends Component {
   constructor (props) {
     super(props)
+
+    const selectedSubjects = props.data.filter((subject) => subject.selected)
     this.state = {
-      selected: props.data.filter((subject) => subject.selected),
+      selected: selectedSubjects,
+      hoveredSubject: null,
+      maxOrder: Math.max(...selectedSubjects.map((item) => typy(item, 'order').safeNumber)),
     }
     this.nextStep = this.nextStep.bind(this)
     this.skipStep = this.skipStep.bind(this)
     this.makeSubjectColumns = this.makeSubjectColumns.bind(this)
     this.onCheckboxChanged = this.onCheckboxChanged.bind(this)
+    this.onSubjectEnter = this.onSubjectEnter.bind(this)
+    this.onSubjectLeave = this.onSubjectLeave.bind(this)
+    this.getTooltip = this.getTooltip.bind(this)
   }
 
   nextStep (event, skipSave) {
@@ -29,16 +40,46 @@ class SubjectStep extends Component {
       return
     }
 
-    const stateObj = JSON.parse(JSON.stringify(this.state))
+    const stateObj = {
+      ...this.state,
+      selected: JSON.parse(JSON.stringify(this.state.selected)),
+    }
     if (event.target.checked) {
-      const match = this.props.data.find((item) => item.fields.slug === event.target.name)
+      const match = this.props.data.find((item) => item.fields.page.fields.slug === event.target.name)
       if (match) {
+        // If order is falsy and NOT 0, add an order attribute that will append the item at the end of the list
+        if (!match.order && match.order !== 0) {
+          match.order = ++stateObj.maxOrder
+        }
         stateObj.selected.push(match)
       }
     } else {
-      stateObj.selected = stateObj.selected.filter((item) => item.fields.slug !== event.target.name)
+      stateObj.selected = stateObj.selected.filter((item) => item.fields.page.fields.slug !== event.target.name)
     }
     this.setState(stateObj)
+  }
+
+  onSubjectEnter (event) {
+    this.setState({
+      hoveredSubject: event.target,
+    })
+  }
+
+  onSubjectLeave () {
+    this.setState({
+      hoveredSubject: null,
+    })
+  }
+
+  getTooltip (dataTooltip) {
+    // only display if hovering text is truncated
+    if (!this.state.hoveredSubject ||
+      !dataTooltip ||
+      this.state.hoveredSubject.scrollWidth === this.state.hoveredSubject.clientWidth
+    ) {
+      return null
+    }
+    return this.state.hoveredSubject.textContent
   }
 
   makeSubjectColumns () {
@@ -48,17 +89,21 @@ class SubjectStep extends Component {
     for (let i = 0; i < columnCount; i++) {
       output.push(
         <div key={'column_' + i} className='column col-xs-12 col-sm-6 col-md-6 col-lg-3'>
-          {this.props.data.slice(maxPerColumn * i, maxPerColumn * (i + 1)).map((entry) => (
-            <label key={entry.sys.id} className='subject-checkbox-container'>
-              <input
-                type='checkbox'
-                name={entry.fields.slug}
-                onChange={this.onCheckboxChanged}
-                defaultChecked={entry.selected}
-              />
-              <span>{entry.fields.alternateTitle || entry.fields.title}</span>
-            </label>
-          ))}
+          { helper.sortList(this.props.data, 'linkText', 'asc')
+            .slice(maxPerColumn * i, maxPerColumn * (i + 1)).map((entry) => {
+              const title = (entry.fields.usePageTitle && entry.fields.page)
+                ? entry.fields.page.fields.title
+                : entry.fields.title
+              return (
+                <label key={entry.sys.id} className='subject-checkbox-container'>
+                  <input type='checkbox' name={entry.fields.page.fields.slug} onChange={this.onCheckboxChanged} defaultChecked={entry.selected} />
+                  <span data-tip={title} onMouseEnter={this.onSubjectEnter} onMouseLeave={this.onSubjectLeave}>
+                    {title}
+                  </span>
+                </label>
+              )
+            })
+          }
         </div>
       )
     }
@@ -68,10 +113,11 @@ class SubjectStep extends Component {
   render () {
     return (
       <React.Fragment>
+        <ReactTooltip getContent={this.getTooltip} />
         <div className='modal-body'>
           <h4 id='favoritesModalDesc'>Select the subjects that best describes your major or field(s) of study.</h4>
           <div className='gap-top'>
-            <div className='row'>
+            <div className='row subject-wizard-columns'>
               {this.makeSubjectColumns()}
             </div>
           </div>

--- a/src/components/Account/Favorites/Wizard/presenter.js
+++ b/src/components/Account/Favorites/Wizard/presenter.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ReactModal from 'react-modal'
+
+const Wizard = (props) => {
+  return (
+    <ReactModal
+      isOpen
+      shouldCloseOnEsc
+      onRequestClose={props.onDismiss}
+      contentLabel='Favorites Setup'
+      className='modal'
+      overlayClassName='modal-overlay'
+      ariaHideApp
+      aria={{ labelledby: 'favoritesModalTitle', describedby: 'favoritesModalDesc' }}
+      shouldFocusAfterRender
+      shouldReturnFocusAfterClose
+    >
+      <section className='group'>
+        <h3 id='favoritesModalTitle'>
+          <span>Favorites Setup</span>
+          <div className='wizard-step-count-top'>{props.stepNumber}/{props.stepCount}</div>
+          <div className='close-button' title='Close' aria-label='Close' onClick={props.onDismiss} />
+        </h3>
+        {props.children}
+      </section>
+    </ReactModal>
+  )
+}
+
+Wizard.propTypes = {
+  stepCount: PropTypes.number,
+  stepNumber: PropTypes.number,
+  onDismiss: PropTypes.func,
+  children: PropTypes.any,
+}
+
+export default Wizard

--- a/src/components/Account/Favorites/index.js
+++ b/src/components/Account/Favorites/index.js
@@ -6,6 +6,7 @@ import Presenter from './presenter'
 import Loading from 'components/Messages/Loading'
 
 import * as statuses from 'constants/APIStatuses'
+import * as helper from 'constants/HelperFunctions'
 
 import getToken from 'actions/personal/token'
 import { getAllFavorites, clearUpdateFavorites, KIND } from 'actions/personal/favorites'
@@ -58,20 +59,7 @@ class FavoritesContainer extends Component {
 export const mapStateToProps = (state, ownProps) => {
   const { personal, favorites } = state
 
-  const databaseStatus = favorites[KIND.databases] ? favorites[KIND.databases].state : statuses.NOT_FETCHED
-  const subjectStatus = favorites[KIND.subjects] ? favorites[KIND.subjects].state : statuses.NOT_FETCHED
-  let combinedStatus = statuses.NOT_FETCHED
-  if (databaseStatus === subjectStatus) {
-    combinedStatus = databaseStatus
-  } else if (databaseStatus === statuses.ERROR || subjectStatus === statuses.ERROR) {
-    combinedStatus = statuses.ERROR
-  } else if (databaseStatus === statuses.NOT_FETCHED || subjectStatus === statuses.NOT_FETCHED) {
-    // If either one is not fetched, mark as such so that we will know to start fetching
-    combinedStatus = statuses.NOT_FETCHED
-  } else {
-    // Either one is still fetching while the other is SUCCESS... Mark as in progress
-    combinedStatus = statuses.FETCHING
-  }
+  const combinedStatus = helper.reduceStatuses(Object.values(KIND).map((key) => favorites[key].state))
 
   return {
     login: personal.login,

--- a/src/components/Account/Settings/HomePageDisplay/index.js
+++ b/src/components/Account/Settings/HomePageDisplay/index.js
@@ -9,7 +9,8 @@ import RadioList from 'components/Interactive/RadioList'
 
 import { setHideHomeFavorites, setDefaultSearch, clearUpdateSettings, KIND } from 'actions/personal/settings'
 import { saveSearchPreference } from 'actions/search'
-import * as states from 'constants/APIStatuses'
+import * as statuses from 'constants/APIStatuses'
+import * as helper from 'constants/HelperFunctions'
 import { HIDE_HOME_FAVORITES, cookieOptions } from 'constants/cookies'
 import { searchOptions } from 'constants/searchOptions.js'
 
@@ -33,7 +34,7 @@ class HomePageDisplayContainer extends Component {
     stateObj[event.target.name] = event.target.type === 'checkbox' ? event.target.checked : event.target.value
     this.setState(stateObj)
 
-    if (this.props.saveState === states.SUCCESS || this.props.saveState === states.ERROR) {
+    if (this.props.saveState === statuses.SUCCESS || this.props.saveState === statuses.ERROR) {
       this.props.clearUpdateSettings(KIND.hideHomeFavorites)
       this.props.clearUpdateSettings(KIND.defaultSearch)
     }
@@ -41,7 +42,7 @@ class HomePageDisplayContainer extends Component {
 
   onSave = (event) => {
     event.preventDefault()
-    if (this.props.saveState === states.FETCHING) {
+    if (this.props.saveState === statuses.FETCHING) {
       return null
     }
 
@@ -57,7 +58,7 @@ class HomePageDisplayContainer extends Component {
   }
 
   render () {
-    const updateText = this.props.saveState === states.SUCCESS
+    const updateText = this.props.saveState === statuses.SUCCESS
       ? `Saved home page settings successfully.`
       : `Failed to update home page settings. Please refresh and try again.`
 
@@ -95,10 +96,10 @@ class HomePageDisplayContainer extends Component {
                 },
               })}
             />
-            <button type='submit' className='right' aria-label='Save' disabled={!this.props.saveState === states.FETCHING}>
+            <button type='submit' className='right' aria-label='Save' disabled={!this.props.saveState === statuses.FETCHING}>
               Save
             </button>
-            { this.props.saveState === states.FETCHING ? (
+            { this.props.saveState === statuses.FETCHING ? (
               <InlineLoading title='Saving...' className='fright pad-edges-sm' />
             ) : (
               <UpdateStatus className='pad-edges-md' status={this.props.saveState} text={updateText} />
@@ -113,20 +114,11 @@ class HomePageDisplayContainer extends Component {
 export const mapStateToProps = (state) => {
   const { settings } = state
 
-  // If more settings are added, saveState should be a conglomerate of all settings' update statuses
-  let saveState = states.NOT_FETCHED
-  const homeFavoritesState = settings['update'][KIND.hideHomeFavorites].state
-  const defaultSearchState = settings['update'][KIND.defaultSearch].state
-  if (homeFavoritesState === defaultSearchState) {
-    saveState = homeFavoritesState
-  } else if ([homeFavoritesState, defaultSearchState].includes(states.ERROR)) {
-    saveState = states.ERROR
-  } else {
-    saveState = states.FETCHING
-  }
-
   return {
-    saveState: saveState,
+    saveState: helper.reduceStatuses([
+      settings['update'][KIND.hideHomeFavorites].state,
+      settings['update'][KIND.defaultSearch].state,
+    ]),
   }
 }
 

--- a/src/components/DatabaseList/index.js
+++ b/src/components/DatabaseList/index.js
@@ -157,20 +157,7 @@ export const mapStateToProps = (state, thisProps) => {
   const { personal, favorites } = state
 
   // get a status for all letters, either error, fetching or success (not found || success = success)
-  const allLettersStatus = (state.cfDatabaseLetter && state.cfDatabaseLetter.a)
-    ? Object.keys(state.cfDatabaseLetter).map((key) => state.cfDatabaseLetter[key].status)
-      .reduce((a, b) => {
-        const valid = (status) => [statuses.SUCCESS, statuses.NOT_FOUND].includes(status)
-
-        if ([a, b].includes(statuses.ERROR)) {
-          return statuses.ERROR
-        } else if ([a, b].includes(statuses.FETCHING)) {
-          return statuses.FETCHING
-        }
-
-        return (valid(a) && valid(b)) ? statuses.SUCCESS : statuses.ERROR
-      })
-    : statuses.NOT_FETCHED
+  const allLettersStatus = helper.reduceStatuses(Object.keys(state.cfDatabaseLetter).map((key) => state.cfDatabaseLetter[key].status))
 
   return {
     cfDatabaseLetter: sortDbs(state.cfDatabaseLetter),

--- a/src/reducers/contentful/databaseLetter.js
+++ b/src/reducers/contentful/databaseLetter.js
@@ -1,7 +1,12 @@
 import { CF_REQUEST_DATABASE_LETTER, CF_RECEIVE_DATABASE_LETTER } from 'actions/contentful/databaseLetter'
 import * as statuses from 'constants/APIStatuses'
 
-export default (state = {}, action) => {
+const initialState = {}
+'abcdefghijklmnopqrstuvwxyz#'.split('').forEach((char) => {
+  initialState[char] = { status: statuses.NOT_FETCHED }
+})
+
+export default (state = initialState, action) => {
   const letterData = {}
 
   switch (action.type) {

--- a/src/reducers/personal.js
+++ b/src/reducers/personal.js
@@ -1,4 +1,5 @@
 import { RECEIVE_PERSONAL, CLEAR_PERSONAL, REQUEST_PERSONAL } from 'actions/personal/constants'
+import { KIND } from 'actions/personal/favorites'
 import * as statuses from 'constants/APIStatuses'
 
 const initialState = {
@@ -13,7 +14,12 @@ const initialState = {
   historical: { state: statuses.NOT_FETCHED },
   deleteHistorical: { state: statuses.NOT_FETCHED },
   courses: { state: statuses.NOT_FETCHED },
+  favorites: {},
 }
+Object.values(KIND).forEach((value) => {
+  initialState.favorites[value] = { state: statuses.NOT_FETCHED }
+})
+
 const personalReducer = (state = initialState, action) => {
   switch (action.type) {
     case RECEIVE_PERSONAL:

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -4064,6 +4064,10 @@ section.group button.center {
 
 section.group button.right {
   float: right;
+  margin-right: 20px;
+}
+section.group button.right:first-of-type {
+  margin-right: 0;
 }
 
 section.group .modal-footer button {
@@ -4161,7 +4165,7 @@ img.favorite {
 .dnd-remove-area {
   position: relative;
   margin-top: 1em;
-  padding: 1em;
+  min-height: 48px;
   width: 100%;
   border: 2px dashed gray;
   color: gray;
@@ -4350,6 +4354,29 @@ img.favorite {
 
 .subject-checkbox-container input {
   margin: 1px 4px 0 0;
+}
+
+@media only screen and (min-width: 48em) {
+  .subject-checkbox-container span {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .subject-wizard-columns .column:nth-child(odd) {
+    order: 1;
+  }
+  .subject-wizard-columns .column:nth-child(even) {
+    order: 2;
+  }
+}
+@media only screen and (min-width: 75em) {
+  .subject-wizard-columns .column:nth-child(odd) {
+    order: initial;
+  }
+  .subject-wizard-columns .column:nth-child(even) {
+    order: initial;
+  }
 }
 
 @media only screen and (min-width: 48em) {

--- a/src/tests/components/Account/Favorites/Wizard/SubjectStep/index.test.js
+++ b/src/tests/components/Account/Favorites/Wizard/SubjectStep/index.test.js
@@ -19,16 +19,40 @@ describe('components/Account/Favorites/Wizard/SubjectStep', () => {
   const props = {
     data: [
       {
-        sys: { id: '123' },
-        fields: { slug: 'foo', title: 'bar' },
+        sys: { id: 'abc' },
+        fields: {
+          title: 'MINE',
+          page: {
+            sys: { id: '123' },
+            fields: { slug: 'foo', title: 'bar' },
+          },
+          usePageTitle: true,
+        },
+        order: 3,
       },
       {
-        sys: { id: '456' },
-        fields: { slug: 'baz', alternateTitle: 'foobar' },
+        sys: { id: 'def' },
+        fields: {
+          title: 'IM H2O INTOLERANT',
+          page: {
+            sys: { id: '456' },
+            fields: { slug: 'baz', alternateTitle: 'foobar' },
+          },
+          usePageTitle: false,
+        },
+        order: 1,
       },
       {
-        sys: { id: 'xyz' },
-        fields: { slug: 'qux', title: 'quux' },
+        sys: { id: 'ghi' },
+        fields: {
+          title: 'IM OBNOXIOUS',
+          page: {
+            sys: { id: 'xyz' },
+            fields: { slug: 'qux', title: 'quux' },
+          },
+          usePageTitle: true,
+        },
+        order: 2,
       },
     ],
     step: 0,
@@ -64,17 +88,18 @@ describe('components/Account/Favorites/Wizard/SubjectStep', () => {
     props.data.forEach((subject) => {
       const cbx = <input type='checkbox' name={subject.fields.slug} />
       const container = enzymeWrapper.findWhere(el => el.key() === subject.sys.id)
-      expect(container.text()).toEqual(subject.fields.alternateTitle || subject.fields.title)
+      expect(container.exists()).toBe(true)
+      expect(container.text()).toEqual(subject.fields.usePageTitle ? subject.fields.page.fields.title : subject.fields.title)
     })
   })
 
   it('should pass on full selected subject objects when moving to next step', () => {
     const instance = enzymeWrapper.instance()
-    instance.onCheckboxChanged({ target: { name: props.data[0].fields.slug, checked: true } })
-    instance.onCheckboxChanged({ target: { name: props.data[2].fields.slug, checked: true } })
+    instance.onCheckboxChanged({ target: { name: props.data[0].fields.page.fields.slug, checked: true } })
+    instance.onCheckboxChanged({ target: { name: props.data[2].fields.page.fields.slug, checked: true } })
     // Test selecting and deselecting
-    instance.onCheckboxChanged({ target: { name: props.data[1].fields.slug, checked: true } })
-    instance.onCheckboxChanged({ target: { name: props.data[1].fields.slug, checked: false } })
+    instance.onCheckboxChanged({ target: { name: props.data[1].fields.page.fields.slug, checked: true } })
+    instance.onCheckboxChanged({ target: { name: props.data[1].fields.page.fields.slug, checked: false } })
 
     instance.nextStep() // Note that the instance's nextStep() method is NOT the same as the props.nextStep passed in
 

--- a/src/tests/components/Account/Favorites/Wizard/SubjectStep/index.test.js
+++ b/src/tests/components/Account/Favorites/Wizard/SubjectStep/index.test.js
@@ -52,7 +52,19 @@ describe('components/Account/Favorites/Wizard/SubjectStep', () => {
           },
           usePageTitle: true,
         },
-        order: 2,
+      },
+      {
+        sys: { id: 'jkl' },
+        fields: {
+          title: 'I SWIM WITH SHARKS',
+          page: {
+            sys: { id: 'auto' },
+            fields: { slug: 'select', title: 'me' },
+          },
+          usePageTitle: false,
+        },
+        order: 17,
+        selected: true,
       },
     ],
     step: 0,
@@ -95,15 +107,18 @@ describe('components/Account/Favorites/Wizard/SubjectStep', () => {
 
   it('should pass on full selected subject objects when moving to next step', () => {
     const instance = enzymeWrapper.instance()
-    instance.onCheckboxChanged({ target: { name: props.data[0].fields.page.fields.slug, checked: true } })
+    instance.onCheckboxChanged({ target: { name: props.data[0].fields.page.fields.slug, checked: true, order: 3 } })
     instance.onCheckboxChanged({ target: { name: props.data[2].fields.page.fields.slug, checked: true } })
     // Test selecting and deselecting
-    instance.onCheckboxChanged({ target: { name: props.data[1].fields.page.fields.slug, checked: true } })
-    instance.onCheckboxChanged({ target: { name: props.data[1].fields.page.fields.slug, checked: false } })
+    instance.onCheckboxChanged({ target: { name: props.data[1].fields.page.fields.slug, checked: true, order: 1 } })
+    instance.onCheckboxChanged({ target: { name: props.data[1].fields.page.fields.slug, checked: false, order: 1 } })
+    // If null target, shouldn't error or do anything weird
+    instance.onCheckboxChanged()
 
     instance.nextStep() // Note that the instance's nextStep() method is NOT the same as the props.nextStep passed in
 
-    const expected = [props.data[0], props.data[2]]
+    // props.data[3] was designated as selected in props, so that's why it is here
+    const expected = [props.data[3], props.data[0], props.data[2]]
     expect(props.nextStep).toHaveBeenLastCalledWith(expected)
   })
 
@@ -112,5 +127,29 @@ describe('components/Account/Favorites/Wizard/SubjectStep', () => {
     instance.skipStep({ preventDefault: jest.fn() })
 
     expect(props.nextStep).not.toHaveBeenLastCalledWith(expect.any(Array))
+  })
+
+  it('should add tooltip on hover for long titles', () => {
+    const instance = enzymeWrapper.instance()
+
+    const tip = 'remember to test your code'
+    const fakeElement = { scrollWidth: 250, clientWidth: 200, textContent: tip }
+    instance.onSubjectEnter({ target: fakeElement })
+    expect(instance.state.hoveredSubject).toEqual(fakeElement)
+    expect(instance.getTooltip(tip)).toEqual(tip)
+
+    instance.onSubjectLeave()
+    expect(instance.state.hoveredSubject).toBeFalsy()
+    expect(instance.getTooltip(tip)).toBeFalsy()
+  })
+
+  it('should not show tooltip for short titles', () => {
+    const instance = enzymeWrapper.instance()
+
+    const tip = 'remember to test your code'
+    const fakeElement = { scrollWidth: 200, clientWidth: 200, textContent: tip }
+    instance.onSubjectEnter({ target: fakeElement })
+    expect(instance.state.hoveredSubject).toEqual(fakeElement)
+    expect(instance.getTooltip(tip)).toBeFalsy()
   })
 })

--- a/src/tests/components/Account/Favorites/Wizard/presenter.test.js
+++ b/src/tests/components/Account/Favorites/Wizard/presenter.test.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ReactModal from 'react-modal'
+
+import Wizard from 'components/Account/Favorites/Wizard/presenter'
+
+let enzymeWrapper
+
+const setup = (props) => {
+  return shallow(<Wizard {...props} />)
+}
+
+describe('components/Account/Favorites/Wizard/presenter.js', () => {
+  afterEach(() => {
+    enzymeWrapper = undefined
+  })
+
+  const props = {
+    stepNumber: 2,
+    stepCount: 3,
+    onDismiss: jest.fn(),
+  }
+
+  beforeEach(() => {
+    enzymeWrapper = setup(props)
+  })
+
+  it('should render inside modal', () => {
+    expect(enzymeWrapper.find(ReactModal).exists()).toBe(true)
+  })
+
+  it('should render close button', () => {
+    const found = enzymeWrapper.find('.close-button')
+    expect(found.exists()).toBe(true)
+    expect(found.props().onClick).toEqual(props.onDismiss)
+  })
+
+  it('should display correct step count', () => {
+    const found = enzymeWrapper.find('.wizard-step-count-top')
+    expect(found.exists()).toBe(true)
+    expect(found.text()).toEqual(`${props.stepNumber}/${props.stepCount}`)
+
+    // Try some random numbers, just to be sure :)
+    let times = 0
+    while (times < 10) {
+      const number1 = Math.floor(Math.random() * 100)
+      const number2 = Math.floor(Math.random() * 100)
+      enzymeWrapper = setup({
+        stepNumber: number1,
+        stepCount: number2,
+        onDismiss: jest.fn(),
+      })
+
+      expect(enzymeWrapper.find('.wizard-step-count-top').text()).toEqual(`${number1}/${number2}`)
+
+      times++
+    }
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -9222,6 +9222,14 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.13.6"
 
+react-tooltip@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.10.0.tgz#268b5ef519fd8a1369288d1f086f42c90d5da7ef"
+  integrity sha512-GGdxJvM1zSFztkTP7gCQbLTstWr1OOoMpJ5WZUGhimj0nhRY+MPz+92MpEnKmj0cftJ9Pd/M6FfSl0sfzmZWkg==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"


### PR DESCRIPTION
Fixes a number of issues the favorites wizard was having with the newly updated model for subjects. Also enhances the wizard so that it can be reopened for specific steps and will load existing favorites data in order to allow modifying after initial selection. Fixed some formatting issues as well, and added more tests.