### PR TITLE
Fix intermittent page rendering problem on secure pages

### DIFF
--- a/src/components/Contentful/SecurePage/index.js
+++ b/src/components/Contentful/SecurePage/index.js
@@ -11,7 +11,7 @@ import { withErrorBoundary } from 'components/ErrorBoundary'
 const mapStateToProps = (state) => {
   return {
     cfPageEntry: state.cfPageEntry,
-    login: state.personal.login,
+    login: Object.assign({}, { ...state.personal.login }),
   }
 }
 


### PR DESCRIPTION
Reported problem: Secure pages intermittently get stuck on Loading animation.

Technical problem: `mapStateToProps` was not updating `this.props.login` correctly because of some internal optimizations that redux does durring mapStateToProps.

Solution: `this.props.login` is assigned as an immutable object with `Object.assign` instead of directly setting it to `state.personal.login`

https://redux.js.org/faq/react-redux#why-isn-t-my-component-re-rendering-or-my-mapstatetoprops-running