### PR TITLE
Fix incorrect librarians showing up when changing pages.

### DIFF
--- a/src/components/Contentful/Page/index.js
+++ b/src/components/Contentful/Page/index.js
@@ -40,7 +40,7 @@ export class ContentfulPageContainer extends Component {
   render () {
     return <PresenterFactory
       presenter={ContentfulPagePresenter}
-      status={this.props.cfPageEntry.status}
+      status={this.props.cfPageEntry.slug === this.props.match.params.id ? this.props.cfPageEntry.status : statuses.NOT_FETCHED}
       props={{ cfPageEntry: this.props.cfPageEntry.json }} />
   }
 }

--- a/src/components/Contentful/ServicePoint/index.js
+++ b/src/components/Contentful/ServicePoint/index.js
@@ -46,7 +46,7 @@ export class ServicePointContainer extends Component {
   }
 
   render () {
-    if (!this.state.sp || !this.state.sp.fields) {
+    if (!this.state.sp || !this.state.sp.fields || (this.props.slug && this.state.sp.fields.slug !== this.props.slug)) {
       return null
     }
 

--- a/src/components/Librarians/index.js
+++ b/src/components/Librarians/index.js
@@ -9,11 +9,9 @@ import { withErrorBoundary } from 'components/ErrorBoundary'
 const mapStateToProps = (state, ownProps) => {
   const { librarianInfo } = state
 
-  const info = (librarianInfo && librarianInfo.netids) ? librarianInfo : { status: statuses.NOT_FOUND }
-
   return {
     // only those librarians for this page will affect this page
-    librarianInfo: info,
+    librarianInfo,
     ...ownProps,
   }
 }
@@ -24,8 +22,8 @@ const mapDispatchToProps = (dispatch) => {
 
 export class LibrariansContainer extends Component {
   componentDidMount () {
-    if (this.props.librarianInfo.status !== statuses.FETCHING ||
-    !this.props.netids.equals(this.props.librarianInfo.netids)) {
+    if ([statuses.NOT_FETCHED, statuses.ERROR].includes(this.props.librarianInfo.status) ||
+      (this.props.librarianInfo.netids && !this.props.netids.equals(this.props.librarianInfo.netids))) {
       this.props.fetchLibrarians(this.props.netids)
     }
   }

--- a/src/reducers/contentful/page.js
+++ b/src/reducers/contentful/page.js
@@ -7,6 +7,7 @@ export default (state = { status: statuses.NOT_FETCHED }, action) => {
       return Object.assign({}, state, {
         status: statuses.FETCHING,
         slug: action.slug,
+        json: null, // Clear out any old data in case slug changed
       })
     case CF_RECEIVE_PAGE:
       return Object.assign({}, state, {

--- a/src/reducers/contentful/staticContent.js
+++ b/src/reducers/contentful/staticContent.js
@@ -7,6 +7,7 @@ export default (state = { status: statuses.NOT_FETCHED }, action) => {
       return Object.assign({}, state, {
         status: statuses.FETCHING,
         slug: action.slug,
+        json: null, // Clear out any old data in case slug changed
       })
     case CF_RECEIVE_SIDEBAR:
       return Object.assign({}, state, {

--- a/src/reducers/librarians.js
+++ b/src/reducers/librarians.js
@@ -1,7 +1,7 @@
 import * as statuses from 'constants/APIStatuses'
 import { REQUEST_LIBRARIANS, RECEIVE_LIBRARIANS } from 'actions/librarians'
 
-export default (state = { status: statuses.FETCHING }, action) => {
+export default (state = { status: statuses.NOT_FETCHED }, action) => {
   switch (action.type) {
     case REQUEST_LIBRARIANS:
       return Object.assign({}, state, {

--- a/src/tests/components/Contentful/Page/index.test.js
+++ b/src/tests/components/Contentful/Page/index.test.js
@@ -17,7 +17,7 @@ describe('components/Contentful/Page/Container', () => {
   describe('normal page', () => {
     beforeEach(() => {
       props = {
-        cfPageEntry: { status: 'test', json: { sys: { contentType: { sys: { id: 'page' } } } } },
+        cfPageEntry: { status: 'test', slug: 'fake page slug', json: { sys: { contentType: { sys: { id: 'page' } } } } },
         fetchPage: jest.fn(),
         clearPage: jest.fn(),
         match: { params: { id: 'fake page slug' } },
@@ -69,6 +69,7 @@ describe('components/Contentful/Page/Container', () => {
       props = {
         cfPageEntry: {
           status: statuses.UNAUTHORIZED,
+          slug: 'fake page slug',
           json: {
             sys: { contentType: { sys: { id: 'page' } } },
             fields: {

--- a/src/tests/reducers/contentful/page.test.js
+++ b/src/tests/reducers/contentful/page.test.js
@@ -15,9 +15,12 @@ describe('Page reducer', () => {
     expect(
       reducer(undefined, {
         type: actions.CF_REQUEST_PAGE,
+        slug: 'test',
       })
     ).toEqual({
       status: statuses.FETCHING,
+      slug: 'test',
+      json: null,
     })
   })
 

--- a/src/tests/reducers/librarians.test.js
+++ b/src/tests/reducers/librarians.test.js
@@ -7,7 +7,7 @@ describe('Page reducer', () => {
     expect(
       reducer(undefined, {})
     ).toEqual({
-      status: statuses.FETCHING,
+      status: statuses.NOT_FETCHED,
     })
   })
 
@@ -15,9 +15,11 @@ describe('Page reducer', () => {
     expect(
       reducer(undefined, {
         type: actions.REQUEST_LIBRARIANS,
+        netids: ['a123', 'b456'],
       })
     ).toEqual({
       status: statuses.FETCHING,
+      netids: ['a123', 'b456'],
     })
   })
 


### PR DESCRIPTION
In essence, this was happening because when you change pages, the previous page is still loaded in the store. This caused the new page to render the old page for a brief moment, and this triggers a request to fetch librarian info. When the slug updates, it fetches the librarian info for the new slug and a race condition starts.

Simple solution: Don't render anything if the page in the store does not match the route you are on. Wait for the new page to be fetched.