### PR TITLE
Add rbsc and archives to robots.txt.

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,3 +6,5 @@ Disallow: /floor/search
 Disallow: /search?*
 Disallow: /resource-technical-problem
 Disallow: /resource-unavailable
+Disallow: /rbsc
+Disallow: /archives


### PR DESCRIPTION
These are dumby "pages" that merely exist so they can be used as preferred locations. They have no content, so we don't want them showing up in search results.