### PR TITLE
LW-706 Send Contentful preview requests to livequery to reduce cache time.

### DIFF
--- a/src/actions/contentful/allEvents.js
+++ b/src/actions/contentful/allEvents.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_ALLEVENTS = 'CF_REQUEST_ALLEVENTS'
@@ -37,12 +37,7 @@ const receiveAllEvents = (response) => {
 }
 
 export const fetchAllEvents = (status) => {
-  const query = encodeURIComponent('content_type=event&include=3')
-  const preview = status === 'preview'
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl('content_type=event&include=3', status === 'preview')
 
   return dispatch => {
     dispatch(requestAllEvents())

--- a/src/actions/contentful/allEvents.js
+++ b/src/actions/contentful/allEvents.js
@@ -39,7 +39,7 @@ const receiveAllEvents = (response) => {
 export const fetchAllEvents = (status) => {
   const query = encodeURIComponent('content_type=event&include=3')
   const preview = status === 'preview'
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/allNews.js
+++ b/src/actions/contentful/allNews.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_ALLNEWS = 'CF_REQUEST_ALLNEWS'
@@ -37,11 +37,7 @@ const receiveAllNews = (response) => {
 }
 
 export const fetchAllNews = (preview) => {
-  const query = encodeURIComponent('content_type=news&include=3')
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl('content_type=news&include=3', preview)
 
   return dispatch => {
     dispatch(requestAllNews())

--- a/src/actions/contentful/allNews.js
+++ b/src/actions/contentful/allNews.js
@@ -38,7 +38,7 @@ const receiveAllNews = (response) => {
 
 export const fetchAllNews = (preview) => {
   const query = encodeURIComponent('content_type=news&include=3')
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/branches.js
+++ b/src/actions/contentful/branches.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_BRANCHES = 'CF_REQUEST_BRANCHES'
@@ -38,11 +38,7 @@ const receiveBranches = (response, depth) => {
 }
 
 export const fetchBranches = (preview, include = 0) => {
-  const query = encodeURIComponent(`content_type=page&fields.type=Branch&include=${include}&order=fields.title`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=page&fields.type=Branch&include=${include}&order=fields.title`, preview)
 
   return (dispatch, getState) => {
     dispatch(requestBranches(include))

--- a/src/actions/contentful/branches.js
+++ b/src/actions/contentful/branches.js
@@ -38,9 +38,8 @@ const receiveBranches = (response, depth) => {
 }
 
 export const fetchBranches = (preview, include = 0) => {
-  const endpoint = 'query'
   const query = encodeURIComponent(`content_type=page&fields.type=Branch&include=${include}&order=fields.title`)
-  let url = `${Config.contentfulAPI}/${endpoint}?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/database.js
+++ b/src/actions/contentful/database.js
@@ -1,6 +1,5 @@
 import fetch from 'isomorphic-fetch'
 import typy from 'typy'
-import Config from 'shared/Configuration'
 import * as statuses from 'constants/APIStatuses'
 import * as helper from 'constants/HelperFunctions'
 
@@ -72,11 +71,7 @@ const receiveDatabaseDefaults = (response) => {
 }
 
 export const fetchLetter = (letter, preview) => {
-  const query = encodeURIComponent(`content_type=resource&fields.databaseLetter=${letter}&include=1`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=resource&fields.databaseLetter=${letter}&include=1`, preview)
 
   return (dispatch, getState) => {
     dispatch(requestLetter(letter))
@@ -109,11 +104,7 @@ export const fetchLetter = (letter, preview) => {
 export const fetchDefaultDbFavorites = (preview) => {
   // Academic Search Premier, JSTOR, and Scopus
   const alephIds = ['002056133', '001517508', '004862587']
-  const query = encodeURIComponent(`content_type=resource&fields.alephSystemNumber[in]=${alephIds.join(',')}&include=0`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=resource&fields.alephSystemNumber[in]=${alephIds.join(',')}&include=0`, preview)
 
   return dispatch => {
     dispatch(requestDatabaseDefaults())

--- a/src/actions/contentful/database.js
+++ b/src/actions/contentful/database.js
@@ -73,7 +73,7 @@ const receiveDatabaseDefaults = (response) => {
 
 export const fetchLetter = (letter, preview) => {
   const query = encodeURIComponent(`content_type=resource&fields.databaseLetter=${letter}&include=1`)
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }
@@ -110,7 +110,7 @@ export const fetchDefaultDbFavorites = (preview) => {
   // Academic Search Premier, JSTOR, and Scopus
   const alephIds = ['002056133', '001517508', '004862587']
   const query = encodeURIComponent(`content_type=resource&fields.alephSystemNumber[in]=${alephIds.join(',')}&include=0`)
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/entry.js
+++ b/src/actions/contentful/entry.js
@@ -54,7 +54,7 @@ export const fetchEntry = (id, slug, preview) => {
     identifierParam = encodeURIComponent(`sys.id=${id}&include=3`)
     entryIdent = id
   }
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${identifierParam}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${identifierParam}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/entry.js
+++ b/src/actions/contentful/entry.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_ENTRY = 'CF_REQUEST_ENTRY'
@@ -51,13 +51,10 @@ export const fetchEntry = (id, slug, preview) => {
   }
   */
   if (id) {
-    identifierParam = encodeURIComponent(`sys.id=${id}&include=3`)
+    identifierParam = `sys.id=${id}&include=3`
     entryIdent = id
   }
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${identifierParam}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(identifierParam, preview)
 
   return (dispatch, getState) => {
     dispatch(requestEntry(entryIdent))

--- a/src/actions/contentful/event.js
+++ b/src/actions/contentful/event.js
@@ -41,7 +41,7 @@ const receiveEvent = (event, response) => {
 
 export const fetchEvent = (event, preview) => {
   const query = encodeURIComponent(`content_type=event&fields.slug=${event}&include=3`)
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/event.js
+++ b/src/actions/contentful/event.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_EVENT = 'CF_REQUEST_EVENT'
@@ -40,11 +40,7 @@ const receiveEvent = (event, response) => {
 }
 
 export const fetchEvent = (event, preview) => {
-  const query = encodeURIComponent(`content_type=event&fields.slug=${event}&include=3`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=event&fields.slug=${event}&include=3`, preview)
 
   return (dispatch) => {
     dispatch(requestEvent(event))

--- a/src/actions/contentful/floor.js
+++ b/src/actions/contentful/floor.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_FLOOR = 'CF_REQUEST_FLOOR'
@@ -38,11 +38,7 @@ const receiveFloor = (floor, response) => {
 }
 
 export const fetchFloor = (floor, preview) => {
-  const query = encodeURIComponent(`content_type=floor&fields.slug=${floor}`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=floor&fields.slug=${floor}`, preview)
 
   return dispatch => {
     dispatch(requestFloor(floor))

--- a/src/actions/contentful/floor.js
+++ b/src/actions/contentful/floor.js
@@ -39,7 +39,7 @@ const receiveFloor = (floor, response) => {
 
 export const fetchFloor = (floor, preview) => {
   const query = encodeURIComponent(`content_type=floor&fields.slug=${floor}`)
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}&preview=${preview}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/internalLink.js
+++ b/src/actions/contentful/internalLink.js
@@ -5,7 +5,7 @@ import Config from 'shared/Configuration'
 // will then transform the data to get the desired result.
 export const fetchInternalLinks = (preview) => {
   const query = encodeURIComponent(`content_type=internalLink&include=1`)
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/internalLink.js
+++ b/src/actions/contentful/internalLink.js
@@ -1,13 +1,9 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 
 // Note that these do NOT go into the store like most actions... It is presumed that the caller is another action which
 // will then transform the data to get the desired result.
 export const fetchInternalLinks = (preview) => {
-  const query = encodeURIComponent(`content_type=internalLink&include=1`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=internalLink&include=1`, preview)
   return fetch(url).then(response => response.ok ? response.json() : { errorStatus: response.status })
 }

--- a/src/actions/contentful/news.js
+++ b/src/actions/contentful/news.js
@@ -39,7 +39,7 @@ const receiveNews = (news, response) => {
 
 export const fetchNews = (news, preview) => {
   const query = encodeURIComponent(`content_type=news&fields.slug=${news}&include=3`)
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/news.js
+++ b/src/actions/contentful/news.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_NEWS = 'CF_REQUEST_NEWS'
@@ -38,11 +38,7 @@ const receiveNews = (news, response) => {
 }
 
 export const fetchNews = (news, preview) => {
-  const query = encodeURIComponent(`content_type=news&fields.slug=${news}&include=3`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=news&fields.slug=${news}&include=3`, preview)
 
   return (dispatch) => {
     dispatch(requestNews(news))

--- a/src/actions/contentful/page.js
+++ b/src/actions/contentful/page.js
@@ -53,7 +53,7 @@ export function clearPage () {
 }
 
 export const fetchPage = (page, preview, secure = false, cfType = 'page', include = 3) => {
-  let endpoint = 'query'
+  let endpoint = preview ? 'livequery' : 'query'
   if (secure) {
     endpoint = 'secureQuery'
   }

--- a/src/actions/contentful/page.js
+++ b/src/actions/contentful/page.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_PAGE = 'CF_REQUEST_PAGE'
@@ -53,15 +53,7 @@ export function clearPage () {
 }
 
 export const fetchPage = (page, preview, secure = false, cfType = 'page', include = 3) => {
-  let endpoint = preview ? 'livequery' : 'query'
-  if (secure) {
-    endpoint = 'secureQuery'
-  }
-  const query = encodeURIComponent(`content_type=${cfType}&fields.slug=${page}&include=${include}`)
-  let url = `${Config.contentfulAPI}/${endpoint}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=${cfType}&fields.slug=${page}&include=${include}`, preview, secure)
 
   return (dispatch, getState) => {
     dispatch(requestPage(page))

--- a/src/actions/contentful/servicePoints.js
+++ b/src/actions/contentful/servicePoints.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_SERVICEPOINTS = 'CF_REQUEST_SERVICEPOINTS'
@@ -76,14 +76,11 @@ const receiveServicePoint = (slug, response) => {
 }
 
 export const fetchServicePoints = (preview, id) => {
-  let query = encodeURIComponent(`content_type=servicePoint&include=3`)
+  let query = `content_type=servicePoint&include=3`
   if (id) {
-    query += encodeURIComponent(`&sys.id=${id}`)
+    query += `&sys.id=${id}`
   }
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(query, preview)
 
   return dispatch => {
     dispatch(requestServicePoints())
@@ -95,11 +92,7 @@ export const fetchServicePoints = (preview, id) => {
 }
 
 export const fetchServicePointBySlug = (slug, preview) => {
-  const query = encodeURIComponent(`content_type=servicePoint&fields.slug=${slug}&include=2`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=servicePoint&fields.slug=${slug}&include=2`, preview)
 
   return (dispatch) => {
     dispatch(requestServicePointBySlug(slug))

--- a/src/actions/contentful/servicePoints.js
+++ b/src/actions/contentful/servicePoints.js
@@ -80,7 +80,7 @@ export const fetchServicePoints = (preview, id) => {
   if (id) {
     query += encodeURIComponent(`&sys.id=${id}`)
   }
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }
@@ -96,7 +96,7 @@ export const fetchServicePoints = (preview, id) => {
 
 export const fetchServicePointBySlug = (slug, preview) => {
   const query = encodeURIComponent(`content_type=servicePoint&fields.slug=${slug}&include=2`)
-  let url = `${Config.contentfulAPI}query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/staticContent.js
+++ b/src/actions/contentful/staticContent.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_SIDEBAR = 'CF_REQUEST_SIDEBAR'
@@ -40,11 +40,7 @@ const receiveSidebar = (slug, response) => {
 }
 
 export const fetchSidebar = (slug, preview) => {
-  const query = encodeURIComponent(`content_type=dynamicPage&fields.slug=${slug}&include=3`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=dynamicPage&fields.slug=${slug}&include=3`, preview)
 
   return (dispatch, getState) => {
     const state = getState()

--- a/src/actions/contentful/staticContent.js
+++ b/src/actions/contentful/staticContent.js
@@ -41,7 +41,7 @@ const receiveSidebar = (slug, response) => {
 
 export const fetchSidebar = (slug, preview) => {
   const query = encodeURIComponent(`content_type=dynamicPage&fields.slug=${slug}&include=3`)
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/contentful/subjects.js
+++ b/src/actions/contentful/subjects.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch'
-import Config from 'shared/Configuration'
+import * as helper from 'constants/HelperFunctions'
 import * as statuses from 'constants/APIStatuses'
 
 export const CF_REQUEST_SUBJECTS = 'CF_REQUEST_SUBJECTS'
@@ -38,11 +38,7 @@ const receiveSubjects = (response, depth) => {
 }
 
 export const fetchSubjects = (preview, include = 1) => {
-  const query = encodeURIComponent(`content_type=internalLink&fields.context=Subject&include=${include}`)
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl(`content_type=internalLink&fields.context=Subject&include=${include}`, preview)
 
   return (dispatch) => {
     dispatch(requestSubjects(include))

--- a/src/actions/contentful/subjects.js
+++ b/src/actions/contentful/subjects.js
@@ -39,7 +39,7 @@ const receiveSubjects = (response, depth) => {
 
 export const fetchSubjects = (preview, include = 1) => {
   const query = encodeURIComponent(`content_type=internalLink&fields.context=Subject&include=${include}`)
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/actions/menu.js
+++ b/src/actions/menu.js
@@ -57,7 +57,7 @@ const receiveNavigation = (response, internalLinks) => {
 
 export const fetchNavigation = (preview) => {
   const query = encodeURIComponent('content_type=columnContainer&fields.slug=navigation&include=4')
-  let url = `${Config.contentfulAPI}/query?locale=en-US&query=${query}`
+  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
   if (preview) {
     url += `&preview=${preview}`
   }

--- a/src/constants/HelperFunctions.js
+++ b/src/constants/HelperFunctions.js
@@ -5,6 +5,7 @@
 import typy from 'typy'
 
 import * as statuses from 'constants/APIStatuses'
+import Config from 'shared/Configuration'
 
 export const filterList = (list, filterFields, filterValue) => {
   const value = filterValue.toLowerCase()
@@ -119,4 +120,13 @@ export const mergeInternalLink = (partialRecord, internalLinks) => {
       ? typy(match, 'fields.page.fields.title').safeString
       : typy(match, 'fields.title').safeString,
   }
+}
+
+export const getContentfulQueryUrl = (query, preview = false, secure = false) => {
+  const endpoint = secure ? 'secureQuery' : (preview ? 'livequery' : 'query')
+  let url = `${Config.contentfulAPI}/${endpoint}?locale=en-US&query=${encodeURIComponent(query)}`
+  if (preview) {
+    url += `&preview=${preview}`
+  }
+  return url
 }

--- a/src/tests/actions/contentful/branches.test.js
+++ b/src/tests/actions/contentful/branches.test.js
@@ -47,7 +47,7 @@ describe('branches fetch action creator', () => {
 
   it('should first create a CF_REQUEST_BRANCHES action', () => {
     nock(Config.contentfulAPI)
-      .get('/query')
+      .get(() => true)
       .query(true) // We don't care what the query string is; just mock it no matter what
       .reply(200, successfulResponse)
 
@@ -63,7 +63,7 @@ describe('branches fetch action creator', () => {
 
   it('should be able to fetch preview content', () => {
     nock(Config.contentfulAPI)
-      .get('/query')
+      .get(() => true)
       .query((queryObj) => queryObj.preview === 'true')
       .reply(200, successfulResponse)
 
@@ -75,7 +75,7 @@ describe('branches fetch action creator', () => {
   describe('on success', () => {
     it('should create a CF_RECEIVE_BRANCHES action with data', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(200, successfulResponse)
 
@@ -96,7 +96,7 @@ describe('branches fetch action creator', () => {
   describe('on error', () => {
     it('should create a CF_RECEIVE_BRANCHES action with a status of unauthorized if response status === 401', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(401)
 
@@ -114,7 +114,7 @@ describe('branches fetch action creator', () => {
 
     it('should create a CF_RECEIVE_BRANCHES action with a status of not found if response status === 404', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(404)
 
@@ -132,7 +132,7 @@ describe('branches fetch action creator', () => {
 
     it('should create a CF_RECEIVE_BRANCHES action with an error if response status some other error', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(500)
 
@@ -150,7 +150,7 @@ describe('branches fetch action creator', () => {
 
     it('should create a CF_RECEIVE_BRANCHES action with a status of not found if no response body', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(200)
 

--- a/src/tests/actions/contentful/database.test.js
+++ b/src/tests/actions/contentful/database.test.js
@@ -48,7 +48,7 @@ describe('database fetch action creator', () => {
   describe('database letter', () => {
     it('should first create a CF_REQUEST_DATABASE_LETTER action', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true) // We don't care what the query string is; just mock it no matter what
         .reply(200, successfulResponse)
 
@@ -64,7 +64,7 @@ describe('database fetch action creator', () => {
 
     it('should be able to fetch preview content', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query((queryObj) => queryObj.preview === 'true')
         .reply(200, successfulResponse)
 
@@ -81,7 +81,7 @@ describe('database fetch action creator', () => {
     describe('on success', () => {
       it('should create a CF_RECEIVE_DATABASE_LETTER action with data', () => {
         nock(Config.contentfulAPI)
-          .get('/query')
+          .get(() => true)
           .query(true)
           .reply(200, successfulResponse)
 
@@ -103,7 +103,7 @@ describe('database fetch action creator', () => {
     describe('on error', () => {
       it('should create a CF_RECEIVE_DATABASE_LETTER action with a status of error if response status !== 200', () => {
         nock(Config.contentfulAPI)
-          .get('/query')
+          .get(() => true)
           .query(true)
           .reply(401)
 
@@ -122,7 +122,7 @@ describe('database fetch action creator', () => {
 
       it('should create a CF_RECEIVE_DATABASE_LETTER action with a status of not found if response status === 200', () => {
         nock(Config.contentfulAPI)
-          .get('/query')
+          .get(() => true)
           .query(true)
           .reply(200)
 
@@ -144,7 +144,7 @@ describe('database fetch action creator', () => {
   describe('database default favorites', () => {
     it('should first create a CF_REQUEST_DATABASE_DEFAULT_FAVORITES action', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true) // We don't care what the query string is; just mock it no matter what
         .reply(200, successfulResponse)
 
@@ -159,7 +159,7 @@ describe('database fetch action creator', () => {
 
     it('should be able to fetch preview content', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query((queryObj) => queryObj.preview === 'true')
         .reply(200, successfulResponse)
 
@@ -175,7 +175,7 @@ describe('database fetch action creator', () => {
     describe('on success', () => {
       it('should create a CF_RECEIVE_DATABASE_DEFAULT_FAVORITES action with data', () => {
         nock(Config.contentfulAPI)
-          .get('/query')
+          .get(() => true)
           .query(true)
           .reply(200, successfulResponse)
 
@@ -196,7 +196,7 @@ describe('database fetch action creator', () => {
     describe('on error', () => {
       it('should create a CF_RECEIVE_DATABASE_DEFAULT_FAVORITES action with a status of unauthorized if response status === 401', () => {
         nock(Config.contentfulAPI)
-          .get('/query')
+          .get(() => true)
           .query(true)
           .reply(401)
 
@@ -214,7 +214,7 @@ describe('database fetch action creator', () => {
 
       it('should create a CF_RECEIVE_DATABASE_DEFAULT_FAVORITES action with a status of not found if response status === 404', () => {
         nock(Config.contentfulAPI)
-          .get('/query')
+          .get(() => true)
           .query(true)
           .reply(404)
 
@@ -232,7 +232,7 @@ describe('database fetch action creator', () => {
 
       it('should create a CF_RECEIVE_DATABASE_DEFAULT_FAVORITES action with an error if response status some other error', () => {
         nock(Config.contentfulAPI)
-          .get('/query')
+          .get(() => true)
           .query(true)
           .reply(500)
 
@@ -250,7 +250,7 @@ describe('database fetch action creator', () => {
 
       it('should create a CF_RECEIVE_DATABASE_DEFAULT_FAVORITES action with an error if no response body', () => {
         nock(Config.contentfulAPI)
-          .get('/query')
+          .get(() => true)
           .query(true)
           .reply(200)
 

--- a/src/tests/actions/contentful/subjects.test.js
+++ b/src/tests/actions/contentful/subjects.test.js
@@ -47,7 +47,7 @@ describe('subjects fetch action creator', () => {
 
   it('should first create a CF_REQUEST_SUBJECTS action', () => {
     nock(Config.contentfulAPI)
-      .get('/query')
+      .get(() => true)
       .query(true) // We don't care what the query string is; just mock it no matter what
       .reply(200, successfulResponse)
 
@@ -63,7 +63,7 @@ describe('subjects fetch action creator', () => {
 
   it('should be able to fetch preview content', () => {
     nock(Config.contentfulAPI)
-      .get('/query')
+      .get(() => true)
       .query((queryObj) => queryObj.preview === 'true')
       .reply(200, successfulResponse)
 
@@ -75,7 +75,7 @@ describe('subjects fetch action creator', () => {
   describe('on success', () => {
     it('should create a CF_RECEIVE_SUBJECTS action with data', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(200, successfulResponse)
 
@@ -96,7 +96,7 @@ describe('subjects fetch action creator', () => {
   describe('on error', () => {
     it('should create a CF_RECEIVE_SUBJECTS action with a status of unauthorized if response status === 401', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(401)
 
@@ -114,7 +114,7 @@ describe('subjects fetch action creator', () => {
 
     it('should create a CF_RECEIVE_SUBJECTS action with a status of not found if response status === 404', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(404)
 
@@ -132,7 +132,7 @@ describe('subjects fetch action creator', () => {
 
     it('should create a CF_RECEIVE_SUBJECTS action with an error if response status some other error', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(500)
 
@@ -150,7 +150,7 @@ describe('subjects fetch action creator', () => {
 
     it('should create a CF_RECEIVE_SUBJECTS action with a status of not found if response status === 200', () => {
       nock(Config.contentfulAPI)
-        .get('/query')
+        .get(() => true)
         .query(true)
         .reply(200)
 

--- a/src/tests/actions/menu.test.js
+++ b/src/tests/actions/menu.test.js
@@ -44,7 +44,7 @@ describe('menu actions', () => {
       status: 500,
     }
     nock(Config.contentfulAPI)
-      .get('/query')
+      .get(() => true)
       .query(true)
       .reply(mockResponse.status, mockResponse)
       .persist()
@@ -63,7 +63,7 @@ describe('menu actions', () => {
       code: 500,
     }
     nock(Config.contentfulAPI)
-      .get('/query')
+      .get(() => true)
       .query(true)
       .replyWithError(mockResponse)
       .persist()
@@ -79,7 +79,7 @@ describe('menu actions', () => {
   it('fetch navigation - success', async () => {
     const mockResponse = [{}]
     nock(Config.contentfulAPI)
-      .get('/query')
+      .get(() => true)
       .query(true)
       .reply(200, mockResponse)
       .persist()


### PR DESCRIPTION
Requests to Contentful Direct were still being cached regardless of whether they had the preview flag or not. Since previews could be cached, this meant Contentful users could not get quick feedback from the preview feature as intended.

Sending all previews to livequery will greatly reduce the cache time (currently 30 seconds), which should be a much better experience when trying to rapidly prototype changes in Contentful.