### PR TITLE
LW-706 Fix preview of Contentful content universally

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
-    "autoprefixer": "^9.5.1",
+    "autoprefixer": "^9.6.1",
     "babel-cli": "^6.26.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^9.0.0",
@@ -81,7 +81,7 @@
     "pnp-webpack-plugin": "^1.4.1",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",
-    "postcss-preset-env": "^6.6.0",
+    "postcss-preset-env": "^6.7.0",
     "postcss-safe-parser": "^4.0.1",
     "promise": "^8.0.3",
     "raf": "^3.4.1",

--- a/src/actions/contentful/allAlerts.js
+++ b/src/actions/contentful/allAlerts.js
@@ -38,7 +38,10 @@ const receiveAllAlerts = (response) => {
 
 export const fetchAllAlerts = (preview) => {
   const query = encodeURIComponent('content_type=alert&include=0')
-  const url = `${Config.contentfulAPI}/${preview ? 'preview/query' : 'livequery'}?locale=en-US&query=${query}&t=${Date.now()}`
+  let url = `${Config.contentfulAPI}/${preview ? 'preview/query' : 'livequery'}?locale=en-US&query=${query}&t=${Date.now()}`
+  if (preview) {
+    url += '&preview=true'
+  }
 
   return dispatch => {
     dispatch(requestAllAlerts())

--- a/src/actions/contentful/allAlerts.js
+++ b/src/actions/contentful/allAlerts.js
@@ -40,7 +40,7 @@ export const fetchAllAlerts = (preview) => {
   const query = encodeURIComponent('content_type=alert&include=0')
   let url = `${Config.contentfulAPI}/${preview ? 'preview/query' : 'livequery'}?locale=en-US&query=${query}&t=${Date.now()}`
   if (preview) {
-    url += '&preview=true'
+    url += `&preview=${preview}`
   }
 
   return dispatch => {

--- a/src/actions/contentful/allAlerts.js
+++ b/src/actions/contentful/allAlerts.js
@@ -38,10 +38,7 @@ const receiveAllAlerts = (response) => {
 
 export const fetchAllAlerts = (preview) => {
   const query = encodeURIComponent('content_type=alert&include=0')
-  let url = `${Config.contentfulAPI}/livequery?locale=en-US&query=${query}&t=${Date.now()}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = `${Config.contentfulAPI}/${preview ? 'preview/query' : 'livequery'}?locale=en-US&query=${query}&t=${Date.now()}`
 
   return dispatch => {
     dispatch(requestAllAlerts())

--- a/src/actions/menu.js
+++ b/src/actions/menu.js
@@ -1,7 +1,7 @@
 import fetch from 'isomorphic-fetch'
 import * as statuses from 'constants/APIStatuses'
-import Config from 'shared/Configuration'
 import { fetchInternalLinks } from './contentful/internalLink'
+import * as helper from 'constants/HelperFunctions'
 
 export const OPEN_MENU = 'OPEN_MENU'
 export const CLOSE_MENUS = 'CLOSE_MENUS'
@@ -56,11 +56,7 @@ const receiveNavigation = (response, internalLinks) => {
 }
 
 export const fetchNavigation = (preview) => {
-  const query = encodeURIComponent('content_type=columnContainer&fields.slug=navigation&include=4')
-  let url = `${Config.contentfulAPI}/${preview ? 'livequery' : 'query'}?locale=en-US&query=${query}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
+  const url = helper.getContentfulQueryUrl('content_type=columnContainer&fields.slug=navigation&include=4', preview)
 
   return (dispatch) => {
     dispatch(requestNavigation())

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -65,7 +65,7 @@ const App = (props) => {
     <Switch>
       { Rewrite(props) }
       <Provider store={store}>
-        <PageWrapper>
+        <PageWrapper {...props}>
           <Switch>
             <Route exact path='/' render={() => (<Home {...props} />)} /> {/* Render is needed to pass cookies */}
             <Route exact path='/chat' component={ChatPage} />

--- a/src/components/Contentful/ColumnPage/index.js
+++ b/src/components/Contentful/ColumnPage/index.js
@@ -9,32 +9,17 @@ import ColumnPagePresenter from './presenter.js'
 import { NOT_FETCHED } from 'constants/APIStatuses'
 import { withErrorBoundary } from 'components/ErrorBoundary'
 
-const mapStateToProps = (state, thisProps) => {
-  const slug = thisProps.match.params[0]
-  let page = state.cfPageEntry
-  if (page && page.json && page.json.fields.slug !== slug) {
-    page = { status: NOT_FETCHED }
-  }
-
-  return { cfPageEntry: page }
-}
-
-const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ fetchPage }, dispatch)
-}
-
 export class ContentfulColumnPageContainer extends Component {
   componentDidMount () {
     const pageSlug = this.props.match.params[0]
-    const preview = (new URLSearchParams(this.props.location.search)).get('preview') === 'true'
-    this.props.fetchPage(pageSlug, preview, false, 'columnContainer', 4)
+    this.props.fetchPage(pageSlug, this.props.preview, false, 'columnContainer', 4)
   }
 
   componentWillReceiveProps (nextProps) {
     const slug = this.props.match.params[0]
     const nextSlug = nextProps.match.params[0]
     if (!slug || slug !== nextSlug) {
-      this.props.fetchPage(nextSlug, false, false, 'columnContainer', 4)
+      this.props.fetchPage(nextSlug, nextProps.preview, false, 'columnContainer', 4)
     }
   }
 
@@ -46,6 +31,23 @@ export class ContentfulColumnPageContainer extends Component {
   }
 }
 
+const mapStateToProps = (state, thisProps) => {
+  const slug = thisProps.match.params[0]
+  let page = state.cfPageEntry
+  if (page && page.json && page.json.fields.slug !== slug) {
+    page = { status: NOT_FETCHED }
+  }
+
+  return {
+    cfPageEntry: page,
+    preview: (new URLSearchParams(thisProps.location.search)).get('preview') === 'true',
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ fetchPage }, dispatch)
+}
+
 ContentfulColumnPageContainer.propTypes = {
   fetchPage: PropTypes.func.isRequired,
   cfPageEntry: PropTypes.object.isRequired,
@@ -53,6 +55,7 @@ ContentfulColumnPageContainer.propTypes = {
   location: PropTypes.shape({
     search: PropTypes.string,
   }),
+  preview: PropTypes.bool,
 }
 
 const ContentfulPage = connect(

--- a/src/components/Contentful/News/index.js
+++ b/src/components/Contentful/News/index.js
@@ -8,26 +8,17 @@ import ContentfulNewsPresenter from './presenter.js'
 import './style.css'
 import { withErrorBoundary } from 'components/ErrorBoundary'
 
-const mapStateToProps = (state) => {
-  return { entry: state.cfNewsEntry }
-}
-
-const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ fetchNews }, dispatch)
-}
-
 export class ContentfulNewsContainer extends Component {
   componentDidMount () {
     const newsSlug = this.props.match.params.id
-    const preview = (new URLSearchParams(this.props.location.search)).get('preview') === 'true'
-    this.props.fetchNews(newsSlug, preview, false)
+    this.props.fetchNews(newsSlug, this.props.preview)
   }
 
   componentWillReceiveProps (nextProps) {
     const slug = this.props.match.params.id
     const nextSlug = nextProps.match.params.id
     if (slug !== nextSlug) {
-      this.props.fetchNews(nextSlug)
+      this.props.fetchNews(nextSlug, nextProps.preview)
     }
   }
 
@@ -39,6 +30,17 @@ export class ContentfulNewsContainer extends Component {
   }
 }
 
+const mapStateToProps = (state, ownProps) => {
+  return {
+    entry: state.cfNewsEntry,
+    preview: (new URLSearchParams(ownProps.location.search)).get('preview') === 'true',
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ fetchNews }, dispatch)
+}
+
 ContentfulNewsContainer.propTypes = {
   fetchNews: PropTypes.func.isRequired,
   entry: PropTypes.object.isRequired,
@@ -46,6 +48,7 @@ ContentfulNewsContainer.propTypes = {
   location: PropTypes.shape({
     search: PropTypes.string,
   }),
+  preview: PropTypes.bool,
 }
 
 const ContentfulNews = connect(

--- a/src/components/FloorSearch/Empty/index.js
+++ b/src/components/FloorSearch/Empty/index.js
@@ -44,10 +44,11 @@ const mapDispatchToProps = (dispatch) => {
   return bindActionCreators({ fetchServicePoints }, dispatch)
 }
 
-class ContactContainer extends Component {
+class FloorSearchEmptyContainer extends Component {
   componentDidMount () {
     if (this.props.servicePointsStatus === statuses.NOT_FETCHED) {
-      this.props.fetchServicePoints(false)
+      const preview = (new URLSearchParams(this.props.location.search)).get('preview') === 'true'
+      this.props.fetchServicePoints(preview)
     }
   }
 
@@ -60,9 +61,12 @@ class ContactContainer extends Component {
   }
 }
 
-ContactContainer.propTypes = {
+FloorSearchEmptyContainer.propTypes = {
   fetchServicePoints: PropTypes.func,
   servicePointsStatus: PropTypes.string,
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }).isRequired,
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ContactContainer)
+export default connect(mapStateToProps, mapDispatchToProps)(FloorSearchEmptyContainer)

--- a/src/components/Home/News/index.js
+++ b/src/components/Home/News/index.js
@@ -32,6 +32,24 @@ export const sortNews = (left, right, withPreferred = false) => {
   return 0
 }
 
+export class AllNewsContainer extends Component {
+  componentDidMount () {
+    if (this.props.allNewsStatus === statuses.NOT_FETCHED) {
+      const preview = (new URLSearchParams(this.props.location.search)).get('preview') === 'true'
+      this.props.fetchAllNews(preview)
+    }
+  }
+
+  render () {
+    return (
+      <PresenterFactory
+        presenter={Presenter}
+        props={this.props.allNews}
+        status={this.props.allNewsStatus} />
+    )
+  }
+}
+
 const mapStateToProps = (state) => {
   let allNews = []
   if (state.allNews && state.allNews.status === statuses.SUCCESS) {
@@ -53,32 +71,18 @@ const mapDispatchToProps = (dispatch) => {
   return bindActionCreators({ fetchAllNews }, dispatch)
 }
 
-export class AllNewsContainer extends Component {
-  componentDidMount () {
-    if (this.props.allNewsStatus === statuses.NOT_FETCHED) {
-      this.props.fetchAllNews(false)
-    }
-  }
-
-  render () {
-    return (
-      <PresenterFactory
-        presenter={Presenter}
-        props={this.props.allNews}
-        status={this.props.allNewsStatus} />
-    )
-  }
-}
-
 AllNewsContainer.propTypes = {
   allNewsStatus: PropTypes.string.isRequired,
   fetchAllNews: PropTypes.func.isRequired,
   allNews: PropTypes.array.isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }).isRequired,
 }
 
-const HoursPage = connect(
+const AllNews = connect(
   mapStateToProps,
   mapDispatchToProps
 )(AllNewsContainer)
 
-export default withErrorBoundary(HoursPage)
+export default withErrorBoundary(AllNews)

--- a/src/components/Hours/Page/index.js
+++ b/src/components/Hours/Page/index.js
@@ -22,7 +22,7 @@ export class HoursPageContainer extends Component {
       this.props.fetchHours()
     }
     if (this.props.servicePointsStatus === statuses.NOT_FETCHED) {
-      this.props.fetchServicePoints(false)
+      this.props.fetchServicePoints(this.props.preview)
     }
     if (this.props.cfStatic.status === statuses.NOT_FETCHED || this.props.cfStatic.slug !== hoursPageSlug) {
       this.props.fetchSidebar(hoursPageSlug, this.props.preview)

--- a/src/components/LandingPages/News/index.js
+++ b/src/components/LandingPages/News/index.js
@@ -34,7 +34,8 @@ const mapDispatchToProps = (dispatch) => {
 export class AllNewsContainer extends Component {
   componentDidMount () {
     if (this.props.allNewsStatus === statuses.NOT_FETCHED) {
-      this.props.fetchAllNews(false)
+      const preview = (new URLSearchParams(this.props.location.search)).get('preview') === 'true'
+      this.props.fetchAllNews(preview)
     }
   }
 
@@ -52,6 +53,9 @@ AllNewsContainer.propTypes = {
   allNewsStatus: PropTypes.string.isRequired,
   fetchAllNews: PropTypes.func.isRequired,
   allNews: PropTypes.array.isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }).isRequired,
 }
 
 const HoursPage = connect(

--- a/src/components/Layout/PageWrapper/index.js
+++ b/src/components/Layout/PageWrapper/index.js
@@ -33,7 +33,8 @@ const mapDispatchToProps = (dispatch) => {
 
 class PageWrapperContainer extends Component {
   componentWillMount () {
-    this.props.fetchNavigation()
+    const preview = (new URLSearchParams(this.props.location.search)).get('preview') === 'true'
+    this.props.fetchNavigation(preview)
   }
 
   render () {
@@ -43,6 +44,9 @@ class PageWrapperContainer extends Component {
 
 PageWrapperContainer.propTypes = {
   fetchNavigation: PropTypes.func.isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }).isRequired,
 }
 
 export default connect(

--- a/src/constants/HelperFunctions.js
+++ b/src/constants/HelperFunctions.js
@@ -135,7 +135,11 @@ export const mergeInternalLink = (partialRecord, internalLinks) => {
 
 export const getContentfulQueryUrl = (query, preview = false, secure = false) => {
   const endpoint = secure ? 'secureQuery' : (preview ? 'preview/query' : 'query')
-  return `${Config.contentfulAPI}/${endpoint}?preview=true&locale=en-US&query=${encodeURIComponent(query)}`
+  let url = `${Config.contentfulAPI}/${endpoint}?locale=en-US&query=${encodeURIComponent(query)}`
+  if (preview) {
+    url += `&preview=${preview}`
+  }
+  return url
 }
 
 export const buildQueryString = (existingQuery, key, values) => {

--- a/src/constants/HelperFunctions.js
+++ b/src/constants/HelperFunctions.js
@@ -135,7 +135,7 @@ export const mergeInternalLink = (partialRecord, internalLinks) => {
 
 export const getContentfulQueryUrl = (query, preview = false, secure = false) => {
   const endpoint = secure ? 'secureQuery' : (preview ? 'preview/query' : 'query')
-  return `${Config.contentfulAPI}/${endpoint}?locale=en-US&query=${encodeURIComponent(query)}`
+  return `${Config.contentfulAPI}/${endpoint}?preview=true&locale=en-US&query=${encodeURIComponent(query)}`
 }
 
 export const buildQueryString = (existingQuery, key, values) => {

--- a/src/constants/HelperFunctions.js
+++ b/src/constants/HelperFunctions.js
@@ -134,12 +134,8 @@ export const mergeInternalLink = (partialRecord, internalLinks) => {
 }
 
 export const getContentfulQueryUrl = (query, preview = false, secure = false) => {
-  const endpoint = secure ? 'secureQuery' : (preview ? 'livequery' : 'query')
-  let url = `${Config.contentfulAPI}/${endpoint}?locale=en-US&query=${encodeURIComponent(query)}`
-  if (preview) {
-    url += `&preview=${preview}`
-  }
-  return url
+  const endpoint = secure ? 'secureQuery' : (preview ? 'preview/query' : 'query')
+  return `${Config.contentfulAPI}/${endpoint}?locale=en-US&query=${encodeURIComponent(query)}`
 }
 
 export const buildQueryString = (existingQuery, key, values) => {

--- a/src/tests/actions/contentful/branches.test.js
+++ b/src/tests/actions/contentful/branches.test.js
@@ -63,13 +63,15 @@ describe('branches fetch action creator', () => {
 
   it('should be able to fetch preview content', () => {
     nock(Config.contentfulAPI)
-      .get(() => true)
-      .query((queryObj) => queryObj.preview === 'true')
+      .get('/preview/query')
+      .query(true)
       .reply(200, successfulResponse)
 
     const store = mockStore(state)
-    store.dispatch(fetchBranches(true, 1))
-    expect(nock.isDone()).toBe(true)
+    return store.dispatch(fetchBranches(true, 1))
+      .then(() => {
+        expect(nock.isDone()).toBe(true)
+      })
   })
 
   describe('on success', () => {

--- a/src/tests/actions/contentful/database.test.js
+++ b/src/tests/actions/contentful/database.test.js
@@ -64,8 +64,8 @@ describe('database fetch action creator', () => {
 
     it('should be able to fetch preview content', () => {
       nock(Config.contentfulAPI)
-        .get(() => true)
-        .query((queryObj) => queryObj.preview === 'true')
+        .get('/preview/query')
+        .query(true)
         .reply(200, successfulResponse)
 
       const expectedAction = {
@@ -74,8 +74,10 @@ describe('database fetch action creator', () => {
       }
 
       const store = mockStore()
-      store.dispatch(fetchLetter(requestLetter, true))
-      expect(nock.isDone()).toBe(true)
+      return store.dispatch(fetchLetter(requestLetter, true))
+        .then(() => {
+          expect(nock.isDone()).toBe(true)
+        })
     })
 
     describe('on success', () => {
@@ -159,8 +161,8 @@ describe('database fetch action creator', () => {
 
     it('should be able to fetch preview content', () => {
       nock(Config.contentfulAPI)
-        .get(() => true)
-        .query((queryObj) => queryObj.preview === 'true')
+        .get('/preview/query')
+        .query(true)
         .reply(200, successfulResponse)
 
       const expectedAction = {
@@ -168,8 +170,10 @@ describe('database fetch action creator', () => {
       }
 
       const store = mockStore()
-      store.dispatch(fetchDefaultDbFavorites(true))
-      expect(nock.isDone()).toBe(true)
+      return store.dispatch(fetchDefaultDbFavorites(true))
+        .then(() => {
+          expect(nock.isDone()).toBe(true)
+        })
     })
 
     describe('on success', () => {

--- a/src/tests/actions/contentful/subjects.test.js
+++ b/src/tests/actions/contentful/subjects.test.js
@@ -63,13 +63,15 @@ describe('subjects fetch action creator', () => {
 
   it('should be able to fetch preview content', () => {
     nock(Config.contentfulAPI)
-      .get(() => true)
-      .query((queryObj) => queryObj.preview === 'true')
+      .get('/preview/query')
+      .query(true)
       .reply(200, successfulResponse)
 
     const store = mockStore()
-    store.dispatch(fetchSubjects(true, 1))
-    expect(nock.isDone()).toBe(true)
+    return store.dispatch(fetchSubjects(true, 1))
+      .then(() => {
+        expect(nock.isDone()).toBe(true)
+      })
   })
 
   describe('on success', () => {

--- a/src/tests/components/Layout/PageWrapper/index.test.js
+++ b/src/tests/components/Layout/PageWrapper/index.test.js
@@ -31,7 +31,12 @@ describe('components/Layout/PageWrapper', () => {
         openMenuId: 1,
       },
     }
-    enzymeWrapper = setup(state, null)
+    props = {
+      location: {
+        search: '?preview=true'
+      },
+    }
+    enzymeWrapper = setup(state, props)
   })
 
   afterEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,17 +1879,18 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@^9.4.9, autoprefixer@^9.5.1:
-  version "9.5.1"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.5.1.tgz#243b1267b67e7e947f28919d786b50d3bb0fb357"
-  integrity sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==
+autoprefixer@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.6.1.tgz#51967a02d2d2300bb01866c1611ec8348d355a47"
+  integrity sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==
   dependencies:
-    browserslist "^4.5.4"
-    caniuse-lite "^1.0.30000957"
+    browserslist "^4.6.3"
+    caniuse-lite "^1.0.30000980"
+    chalk "^2.4.2"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^7.0.14"
-    postcss-value-parser "^3.3.1"
+    postcss "^7.0.17"
+    postcss-value-parser "^4.0.0"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -2441,7 +2442,7 @@ browserslist@^4.0.0:
     electron-to-chromium "^1.3.124"
     node-releases "^1.1.14"
 
-browserslist@^4.3.4, browserslist@^4.4.2, browserslist@^4.5.2, browserslist@^4.5.4:
+browserslist@^4.3.4, browserslist@^4.5.2, browserslist@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.4.tgz#166c4ecef3b51737a42436ea8002aeea466ea2c7"
   integrity sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==
@@ -2449,6 +2450,15 @@ browserslist@^4.3.4, browserslist@^4.4.2, browserslist@^4.5.2, browserslist@^4.5
     caniuse-lite "^1.0.30000955"
     electron-to-chromium "^1.3.122"
     node-releases "^1.1.13"
+
+browserslist@^4.6.3, browserslist@^4.6.4:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.0.tgz#9ee89225ffc07db03409f2fee524dc8227458a17"
+  integrity sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==
+  dependencies:
+    caniuse-lite "^1.0.30000989"
+    electron-to-chromium "^1.3.247"
+    node-releases "^1.1.29"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -2583,15 +2593,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000960:
-  version "1.0.30000960"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000960.tgz#ec48297037e5607f582f246ae7b12bee66a78999"
-  integrity sha512-7nK5qs17icQaX6V3/RYrJkOsZyRNnroA4+ZwxaKJzIKy+crIy0Mz5CBlLySd2SNV+4nbUZeqeNfiaEieUBu3aA==
-
-caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000939, caniuse-lite@^1.0.30000955, caniuse-lite@^1.0.30000957:
-  version "1.0.30000959"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000959.tgz#215d3455866da874179c6170202f0cc64f961cfd"
-  integrity sha512-6BvqmS0VLmY4sJCz6AbIJRQfcns8McDxi424y+3kmtisJeA9/5qslP+K8sqremDau7UU4WSsqdRP032JrqZY8Q==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000955, caniuse-lite@^1.0.30000960, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30000989:
+  version "1.0.30000997"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000997.tgz#ba44a606804f8680894b7042612c2c7f65685b7e"
+  integrity sha512-BQLFPIdj2ntgBNWp9Q64LGUIEmvhKkzzHhUHR3CD5A9Lb7ZKF20/+sgadhFap69lk5XmK1fTUleDclaRFvgVUA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3306,7 +3311,7 @@ css-what@2.1, css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-cssdb@^4.3.0:
+cssdb@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
   integrity sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ==
@@ -3807,6 +3812,11 @@ electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.122, electron-to-chromi
   version "1.3.124"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz#861fc0148748a11b3e5ccebdf8b795ff513fa11f"
   integrity sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==
+
+electron-to-chromium@^1.3.247:
+  version "1.3.266"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.266.tgz#a33fb529c75f8d133e75ea7cbedb73a62f2158d2"
+  integrity sha512-UTuTZ4v8T0gLPHI7U75PXLQePWI65MTS3mckRrnLCkNljHvsutbYs+hn2Ua/RFul3Jt/L3Ht2rLP+dU/AlBfrQ==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -7413,6 +7423,13 @@ node-releases@^1.1.13, node-releases@^1.1.14, node-releases@^1.1.3:
   dependencies:
     semver "^5.3.0"
 
+node-releases@^1.1.29:
+  version "1.1.32"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.32.tgz#485b35c1bf9b4d8baa105d782f8ca731e518276e"
+  integrity sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==
+  dependencies:
+    semver "^5.3.0"
+
 nodemon@^1.18.11:
   version "1.18.11"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.18.11.tgz#d836ab663776e7995570b963da5bfc807e53f6b8"
@@ -8161,7 +8178,7 @@ postcss-color-gray@^5.0.0:
     postcss "^7.0.5"
     postcss-values-parser "^2.0.0"
 
-postcss-color-hex-alpha@^5.0.2:
+postcss-color-hex-alpha@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz#a8d9ca4c39d497c9661e374b9c51899ef0f87388"
   integrity sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==
@@ -8205,19 +8222,19 @@ postcss-convert-values@^4.0.1:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
-postcss-custom-media@^7.0.7:
+postcss-custom-media@^7.0.8:
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz#fffd13ffeffad73621be5f387076a28b00294e0c"
   integrity sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==
   dependencies:
     postcss "^7.0.14"
 
-postcss-custom-properties@^8.0.9:
-  version "8.0.10"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.10.tgz#e8dc969e1e15c555f0b836b7f278ef47e3cdeaff"
-  integrity sha512-GDL0dyd7++goDR4SSasYdRNNvp4Gqy1XMzcCnTijiph7VB27XXpJ8bW/AI0i2VSBZ55TpdGhMr37kMSpRfYD0Q==
+postcss-custom-properties@^8.0.11:
+  version "8.0.11"
+  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz#2d61772d6e92f22f5e0d52602df8fae46fa30d97"
+  integrity sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==
   dependencies:
-    postcss "^7.0.14"
+    postcss "^7.0.17"
     postcss-values-parser "^2.0.1"
 
 postcss-custom-selectors@^5.1.2:
@@ -8585,27 +8602,27 @@ postcss-place@^4.0.1:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
-postcss-preset-env@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/postcss-preset-env/-/postcss-preset-env-6.6.0.tgz#642e7d962e2bdc2e355db117c1eb63952690ed5b"
-  integrity sha512-I3zAiycfqXpPIFD6HXhLfWXIewAWO8emOKz+QSsxaUZb9Dp8HbF5kUf+4Wy/AxR33o+LRoO8blEWCHth0ZsCLA==
+postcss-preset-env@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz#c34ddacf8f902383b35ad1e030f178f4cdf118a5"
+  integrity sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==
   dependencies:
-    autoprefixer "^9.4.9"
-    browserslist "^4.4.2"
-    caniuse-lite "^1.0.30000939"
+    autoprefixer "^9.6.1"
+    browserslist "^4.6.4"
+    caniuse-lite "^1.0.30000981"
     css-blank-pseudo "^0.1.4"
     css-has-pseudo "^0.10.0"
     css-prefers-color-scheme "^3.1.1"
-    cssdb "^4.3.0"
-    postcss "^7.0.14"
+    cssdb "^4.4.0"
+    postcss "^7.0.17"
     postcss-attribute-case-insensitive "^4.0.1"
     postcss-color-functional-notation "^2.0.1"
     postcss-color-gray "^5.0.0"
-    postcss-color-hex-alpha "^5.0.2"
+    postcss-color-hex-alpha "^5.0.3"
     postcss-color-mod-function "^3.0.3"
     postcss-color-rebeccapurple "^4.0.1"
-    postcss-custom-media "^7.0.7"
-    postcss-custom-properties "^8.0.9"
+    postcss-custom-media "^7.0.8"
+    postcss-custom-properties "^8.0.11"
     postcss-custom-selectors "^5.1.2"
     postcss-dir-pseudo-class "^5.0.0"
     postcss-double-position-gradients "^1.0.0"
@@ -8737,6 +8754,11 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
+postcss-value-parser@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz#482282c09a42706d1fc9a069b73f44ec08391dc9"
+  integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
+
 postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
@@ -8750,6 +8772,15 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.5,
   version "7.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
   integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.17:
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.18.tgz#4b9cda95ae6c069c67a4d933029eddd4838ac233"
+  integrity sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"


### PR DESCRIPTION
A new endpoint was created in Contentful Direct to serve up preview requests with a much lower cache time, since the caching was interfering with the need for quick feedback that previews demand. This change calls that endpoint, as well as fixes a few places on the site that did not check for the previews flag at all.