### PR TITLE
LW-792 Include search results that Google filters by default.

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -87,12 +87,7 @@ export const fetchResults = (queryString) => {
   return dispatch => {
     dispatch(siteSearchRequest(queryString))
     const qs = queryString ? QueryString.parse(queryString.replace('?', '')) : ''
-    fetch(
-      'https://www.googleapis.com/customsearch/v1?key=' + Config.gcseKey +
-      '&cx=' + Config.gcseCx +
-      '&q=' + qs.q +
-      '&start=' + (qs.start ? qs.start : '1')
-    )
+    fetch(`https://www.googleapis.com/customsearch/v1?key=${Config.gcseKey}&cx=${Config.gcseCx}&q=${qs.q}&start=${qs.start || '1'}&filter=0`)
       .then(response => response.json())
       .then(json => dispatch(siteSearchResponse(json)))
   }

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -86,8 +86,19 @@ export const siteSearchResponse = (json) => {
 export const fetchResults = (queryString) => {
   return dispatch => {
     dispatch(siteSearchRequest(queryString))
-    const qs = queryString ? QueryString.parse(queryString.replace('?', '')) : ''
-    fetch(`https://www.googleapis.com/customsearch/v1?key=${Config.gcseKey}&cx=${Config.gcseCx}&q=${qs.q}&start=${qs.start || '1'}&filter=0`)
+    const parsedQs = queryString ? QueryString.parse(queryString.replace('?', '')) : ''
+    const queryParams = {
+      key: Config.gcseKey,
+      cx: Config.gcseCx,
+      q: parsedQs.q,
+      start: parsedQs.start || 1,
+      filter: 0,
+    }
+    const requestQs = Object.keys(queryParams)
+      .map(key => `${key}=${encodeURIComponent(queryParams[key])}`)
+      .join('&')
+
+    fetch(`https://www.googleapis.com/customsearch/v1?${requestQs}`)
       .then(response => response.json())
       .then(json => dispatch(siteSearchResponse(json)))
   }

--- a/src/components/SearchPage/SearchPager/index.js
+++ b/src/components/SearchPage/SearchPager/index.js
@@ -2,68 +2,74 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Link from 'components/Interactive/Link'
 import QueryString from 'querystring'
+import typy from 'typy'
 
 const SearchPager = (props) => {
-  const queries = props.queries
+  const queries = typy(props.queries).safeObjectOrEmpty
   const pagerQuery = QueryString.parse(props.pagerQuery.replace(/.*[?]/, ''))
   const qs = `/search?q=${pagerQuery.q}`
 
-  if (queries && queries.request && queries.request[0].totalResults) {
-    const resultCount = queries.request[0].totalResults
-    const pageCount = 10
-    const startIndex = queries.request[0].startIndex
-    const currentPage = Math.ceil(startIndex / pageCount)
-    const length = Math.ceil(resultCount / pageCount)
+  const resultCount = typy(queries, 'request[0].totalResults').safeNumber
+  const pageCount = 10
+  const startIndex = typy(queries, 'request[0].startIndex').safeNumber || props.start || 1
+  const currentPage = Math.ceil(startIndex / pageCount)
+  const length = resultCount > 0 ? Math.ceil(resultCount / pageCount) : currentPage
 
-    let lastPage = currentPage + 4
-    if (lastPage >= length) {
-      lastPage = currentPage + (length - currentPage)
-    }
+  // Don't render page links if no results AND on first page.
+  // This allows us to show previous page links if the user ends up on a page past the last record.
+  if (currentPage === 1 && !resultCount) {
+    return null
+  }
 
-    let startPage = 1
-    if (currentPage > 2) {
-      startPage = currentPage - 2
-    }
+  let lastPage = currentPage + 4
+  if (lastPage >= length) {
+    lastPage = currentPage + (length - currentPage)
+  }
 
-    let loopEnd = startIndex + 40
-    if (loopEnd > resultCount) {
-      loopEnd = resultCount
-    }
+  let startPage = 1
+  if (currentPage > 2) {
+    startPage = currentPage - 2
+  }
 
-    const pager = []
-    if (queries.previousPage) {
-      pager.push(
-        <span key='0'>
-          <Link to={qs + '&start=' + queries.previousPage[0].startIndex}>Previous</Link> </span>
-      )
-    }
+  let loopEnd = startIndex + 40
+  if (loopEnd > resultCount) {
+    loopEnd = resultCount
+  }
 
-    for (let i = startPage; i <= lastPage; i++) {
-      if (i === currentPage) {
-        pager.push(<span key={i}>{i} </span>)
-      } else {
-        pager.push(<span key={i}><Link to={qs + '&start=' + ((i - 1) * pageCount + 1)}>{i}</Link> </span>)
-      }
-    }
-
-    if (queries.nextPage) {
-      pager.push(
-        <span key={length + 1}>
-          <Link to={qs + '&start=' + queries.nextPage[0].startIndex}>Next</Link>
-        </span>
-      )
-    }
-
-    return (
-      <div>{pager}</div>
+  const pager = []
+  const previousStartIndex = queries.previousPage ? queries.previousPage[0].startIndex : (startIndex - pageCount)
+  if (previousStartIndex > 0) {
+    pager.push(
+      <span key='0'>
+        <Link to={qs + '&start=' + previousStartIndex}>Previous</Link> </span>
     )
   }
-  return null
+
+  for (let i = startPage; i <= lastPage; i++) {
+    if (i === currentPage) {
+      pager.push(<span key={i}>{i} </span>)
+    } else {
+      pager.push(<span key={i}><Link to={qs + '&start=' + ((i - 1) * pageCount + 1)}>{i}</Link> </span>)
+    }
+  }
+
+  if (queries.nextPage) {
+    pager.push(
+      <span key={length + 1}>
+        <Link to={qs + '&start=' + queries.nextPage[0].startIndex}>Next</Link>
+      </span>
+    )
+  }
+
+  return (
+    <div className={resultCount === 0 ? 'searchPagerSpace' : ''}>{pager}</div>
+  )
 }
 
 SearchPager.propTypes = {
   queries: PropTypes.object,
   pagerQuery: PropTypes.string,
+  start: PropTypes.number,
 }
 
 export default SearchPager

--- a/src/components/SearchPage/presenter.js
+++ b/src/components/SearchPage/presenter.js
@@ -25,9 +25,10 @@ class SearchPage extends Component {
     let pagerQuery = '/search?q='
     let start = 1
     if (this.props.query) {
-      displayQuery = this.props.query.replace(/(&start=\d+)/, '').replace('?q=', '')
+      const searchParams = new URLSearchParams(this.props.location.search)
+      displayQuery = searchParams.get('q')
       pagerQuery += displayQuery
-      start = parseInt(this.props.query.replace(/(\?q=.*(?=&))/, '').replace('&start=', '') || '1', 10)
+      start = parseInt(searchParams.get('start') || 1, 10)
     }
     return (
       <div className='search-results'>

--- a/src/components/SearchPage/presenter.js
+++ b/src/components/SearchPage/presenter.js
@@ -23,9 +23,11 @@ class SearchPage extends Component {
   render () {
     let displayQuery = ''
     let pagerQuery = '/search?q='
+    let start = 1
     if (this.props.query) {
       displayQuery = this.props.query.replace(/(&start=\d+)/, '').replace('?q=', '')
       pagerQuery += displayQuery
+      start = parseInt(this.props.query.replace(/(\?q=.*(?=&))/, '').replace('&start=', '') || '1')
     }
     return (
       <div className='search-results'>
@@ -35,6 +37,7 @@ class SearchPage extends Component {
         <SearchPager
           queries={this.props.queries}
           pagerQuery={pagerQuery}
+          start={start}
         />
       </div>
     )

--- a/src/components/SearchPage/presenter.js
+++ b/src/components/SearchPage/presenter.js
@@ -27,7 +27,7 @@ class SearchPage extends Component {
     if (this.props.query) {
       displayQuery = this.props.query.replace(/(&start=\d+)/, '').replace('?q=', '')
       pagerQuery += displayQuery
-      start = parseInt(this.props.query.replace(/(\?q=.*(?=&))/, '').replace('&start=', '') || '1')
+      start = parseInt(this.props.query.replace(/(\?q=.*(?=&))/, '').replace('&start=', '') || '1', 10)
     }
     return (
       <div className='search-results'>

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -4115,6 +4115,10 @@ section.group .modal-footer button {
   margin: 0 4px 0 0;
 }
 
+.searchPagerSpace {
+  margin-top: 2rem;
+}
+
 @media only screen and (min-width: 48em) {
   .subject-checkbox-container span {
     overflow: hidden;

--- a/src/tests/components/LandingPages/Events/Past/index.test.js
+++ b/src/tests/components/LandingPages/Events/Past/index.test.js
@@ -154,7 +154,10 @@ describe('components/LandingPages/Events/Past', () => {
       expect(result.filteredEvents).toEqual(expect.arrayContaining(expected))
       expect(result.filteredEvents).toHaveLength(expected.length)
       // Make sure we got at least one result to know it worked
-      expect(expected.length).toBeGreaterThan(0)
+      // We can't do this check on the first of a month because we can't have any past events within the same month
+      if (todayDate.getDate() !== 1) {
+        expect(expected.length).toBeGreaterThan(0)
+      }
       // Also make sure the filter props were set
       expect(result.filterYear).toEqual(testData.todayEvent.startDate.getFullYear())
       expect(result.filterMonth).toEqual(testData.todayEvent.startDate.getMonth())


### PR DESCRIPTION
This also includes a usability improvement that will display the paging links for previous pages even when there are no results. This is helpful when users land on a page past the final result (due to inaccurate result counts), so they can try the page before it instead of returning to page 1 by running the search again.