### PR TITLE
LW-783 CI Release Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@
   * [Redux Developer Tools (Chrome plug-in)](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)
 
 ### Building the urls from the exports
-  To build the apis call this.
-  * cd scrips
-  * yarn install
-  * assume a role that can access the exports
+Before running, you will need to build the config file. All URLs and parameters needed are stored in AWS; run the following to fetch them locally.
+
+  * `cd scripts`
+  * `yarn install`
+  * assume a role that can access the exports (or use `aws-vault`)
   * `node buildConfig.js stage=dev`
-  This must be done before you start the application.
 
 ### Running Locally
 * `yarn start`
@@ -75,28 +75,10 @@
 * `yarn test`
 
 ## Branching Strategy
-We have two main branches, `master` and `UA`. `Master` is "production ready" and is what ends up getting tagged and deployed to production. `UA` is what all branches get merged into for testing and User Aceptance (UA). All development branches should start off of master, interated on and merged into `UA`. After the changes are accepted, that branch may then be merged into `master` and deleted. Remember the **branch** is merged into master, **not UA directly**. This also means **UA should not be merged into your development branch at any time**. We don't want to accidentally get unapproved changes into master.
+We have two main branches, `master` and `prep`. `master` is "production ready" and is what ends up getting tagged and deployed to production. `prep` is what all branches get merged into for testing and User Aceptance (UA). All development branches should start off of master, be iterated on, and merged into `prep` (with a pull request). After the changes are accepted, that branch may then be merged into `master` and deleted. Remember, the **feature branch** is merged into `master`, **not `prep` directly**. This also means **`prep` should not be merged into your development branch at any time**. We don't want to accidentally get unapproved changes into master.
 
 ## Deployment to AWS
- There are three scripts that need to be run to do a full deployment of the stack to one of the 5 environments
- prod|beta|alpha|prep|dev
-
- Each of these require the assumption of the correct role.  testlib for all dev paths alpha|dev|prep.  
-
- 1. go to the deploy directory
- 2. assume either testlib of prod-dev
- 3. run deployServicesLocal.sh stage create|update [--branch]  [--[project]]
- 4. assume either testlib or libnd
- 5. run deployWebsiteLocal stage [--branch]
- 6. assume either testlib or prod-invalidator
- 7. run invalidateCloudFront.sh stage
-
-
-## Cloud Front Invalidation
-First, assume this role: /wse/StackSet-iam-developer-ro-InvalidateCloudFrontRole-1IKWK6RIAXND6
-
-Then, this command needs to be issued via the CLI:
-`aws cloudfront create-invalidation --distribution-id {CloudFrontID} --paths /*`
+A continuous integration pipeline handles all build and deployment to test environments. There is a pipeline for the `prep` branch which is triggered on each push; these changes get deployed to https://prep.library.nd.edu/. The production pipeline is based on `master`. In order to allow for batches of changes to be easily grouped and released together, checkout `master` and run `./release.sh` from the root. This should do everything necessary to prepare a release candidate and kick off the pipeline.
 
 ## Quality and User Acceptance Testing
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# This script will do everything necessary to prepare a new release candidate AFTER all changes have been
+# merged into master. The end result should trigger the CI pipeline, which will build to test and await approval.
+
+# This script will update the version number (and tag), then push to master before it finishes.
+# We really don't want to do that unless your workspace is clean and you're already on master.
+# This reduces the risk of forgetting something you meant to change back, or merge in before release.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ $CURRENT_BRANCH != 'master' ]
+then
+  echo "You must checkout 'master' branch in order to create a new release candidate."
+  exit 1;
+fi
+
+if [ -n "$(git status --porcelain)" ]
+then
+  echo "The git repository has unsaved changes. Please stash or discard before releasing."
+  exit 1;
+fi
+
+# check if you have the scripts necessary to tag the build
+if ! [[ $(command -v tag-build.sh) && $(command -v next-build-identifier.sh) ]]
+then
+  printf "\nThis script requires commandline-tools (github.com/ndlib/commandline-tools).\n"
+  printf "To install with homebrew:\n"
+  printf "brew install ndlib/dlt/commandline-tools\n\n"
+  exit 1;
+fi
+
+# Make sure local copy is fully up-to-date
+echo "Pulling latest git changes..."
+git pull || exit 1;
+git fetch --tags || exit 1;
+
+# Update the VERSION file and push a tag for the version
+tag-build.sh <<< $'y' || exit 1;
+
+# Create a new release version in Sentry and associate
+NEW_VERSION=$(cat VERSION)
+yarn sentry-cli releases new usurper@$NEW_VERSION
+yarn sentry-cli releases set-commits --auto usurper@$NEW_VERSION
+
+# Finally, apply a tag that will trigger the CI pipeline. (Delete first if it exists.)
+TAG_NAME=ci
+if [ $(git tag -l $TAG_NAME) ]
+then
+  git tag -d $TAG_NAME || exit 1;
+  git push origin :refs/tags/$TAG_NAME || exit 1; # push empty ref to remote to delete
+fi
+git tag $TAG_NAME || exit 1;
+git push origin tag $TAG_NAME || exit 1;

--- a/scripts/buildConfig.js
+++ b/scripts/buildConfig.js
@@ -42,7 +42,9 @@ let handler = async () => {
 
     for(let i = 0; i < apiList.length; i++) {
       try {
-        outputs[apiList[i]] = findExport(apiList[i], stage, 'api-url', data['Exports'])
+        outputs[apiList[i]] = (process.env.CI && stage === 'test')
+          ? `https://${apiList[i]}.test.url`
+          : findExport(apiList[i], stage, 'api-url', data['Exports'])
       } catch(err) {
         console.error(`${RED}${err}${NC}`)
         error = true


### PR DESCRIPTION
This script is intended to be run when a group of items have passed UA (on prep) and are ready to prepare a release candidate. Doing it this way allows for us to merge multiple features into master for a given release, instead of triggering the pipeline on every pull. It also maintains more meaningful version numbers. This also creates a nice spot to hook in an automated changelog, if we decide to implement that.

Running this script adds a tag which will trigger a CI build out to test, so a developer preparing a release does not have to do anything beyond merging changes and running `release.sh`.