### PR TITLE
Fix hours status delayed

### DIFF
--- a/src/components/Hours/Current/index.js
+++ b/src/components/Hours/Current/index.js
@@ -26,6 +26,13 @@ export class CurrentHoursContainer extends Component {
     this.tick = this.tick.bind(this)
   }
 
+  componentDidUpdate (prevProps) {
+    // When finished load, force a tick so the open status gets updated in the state before render
+    if (this.props.hoursEntry.status === statuses.SUCCESS && prevProps.hoursEntry.status !== statuses.SUCCESS) {
+      this.tick()
+    }
+  }
+
   componentDidMount () {
     // check current time every second to update color
     const intervalId = setInterval(this.tick, 1000)

--- a/src/tests/components/Hours/Current/index.test.js
+++ b/src/tests/components/Hours/Current/index.test.js
@@ -84,6 +84,35 @@ describe('components/Hours/Current', () => {
     expect(global.clearInterval).toHaveBeenCalled()
   })
 
+  it('should get the open status before first SUCCESS render', () => {
+    const instance = enzymeWrapper.instance()
+    // Initialize as closed
+    instance.setState({
+      openStatus: 'closed',
+    })
+
+    // When tick is called, set to open
+    instance.tick = jest.fn(() => {
+      instance.setState({
+        openStatus: 'open',
+      })
+    })
+
+    // Should trigger a tick since the hoursEntry now has a SUCCESS status
+    const hoursEntry = {
+      status: statuses.SUCCESS,
+      name: 'Some Library IDK',
+      today: {
+        times: {
+          status: '24hours',
+        },
+        rendered: 'All the time, man',
+      },
+    }
+    enzymeWrapper.setProps({ hoursEntry })
+    expect(enzymeWrapper.containsMatchingElement(<Presenter hoursEntry={hoursEntry} openStatus='open' />)).toBe(true)
+  })
+
   describe('with SUCCESS', () => {
     beforeEach(() => {
       props = {


### PR DESCRIPTION
There was an issue where the background of an hours would show up as red (as if the location was closed) on initial render. This is because the status wasn't getting updated until "tick" was called, which would not happen until the next render cycle. This fix resolves this for a better visual experience.