### PR TITLE
Upgrade eslint version for hound to match our installed package version.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,3 +2,4 @@ eslint:
   config_file: .eslintrc
   ignore_file: .eslintignore
   enabled: true
+  version: 5.16.0


### PR DESCRIPTION
This should fix hound throwing errors when it tries to run on our PRs.