### PR TITLE
LW-759 Add favoriting certain external links.

### DIFF
--- a/src/actions/personal/settings.js
+++ b/src/actions/personal/settings.js
@@ -54,7 +54,7 @@ export const setCircStatus = (enabled) => {
   return (dispatch, getState) => {
     const state = getState().personal
     dispatch(requestUpdateSettings(KIND.circStatus))
-    const url = Config.userPrefsAPI + 'circOptIn'
+    const url = Config.userPrefsAPI + '/circOptIn'
     return fetch(url, {
       method: 'post',
       headers: {
@@ -81,7 +81,7 @@ const getSimpleSetting = (kind, defaultValue) => {
   return (dispatch, getState) => {
     const state = getState().personal
     dispatch(requestSettings(kind, null))
-    const url = Config.userPrefsAPI + 'simpleSetting/' + kind
+    const url = Config.userPrefsAPI + '/simpleSetting/' + kind
     return fetch(url, {
       method: 'GET',
       headers: {
@@ -114,7 +114,7 @@ const setSimpleSetting = (kind, value) => {
   return (dispatch, getState) => {
     const state = getState().personal
     dispatch(requestUpdateSettings(kind))
-    const url = Config.userPrefsAPI + 'simpleSetting/' + kind
+    const url = Config.userPrefsAPI + '/simpleSetting/' + kind
     return fetch(url, {
       method: 'POST',
       headers: {

--- a/src/components/Account/Favorites/Wizard/index.js
+++ b/src/components/Account/Favorites/Wizard/index.js
@@ -192,14 +192,24 @@ class Wizard extends Component {
         const hasSubjects = this.state.data[FAVORITES_KIND.subjects].length > 0
         if (!this.state.data[currentStepName] || this.state.data[currentStepName].length === 0) {
           if (hasSubjects) {
-            const relatedDbs = this.props.cfDatabases.data.filter((db) => (
-              db.sys && this.state.data[FAVORITES_KIND.subjects].find((subject) => (
-                typy(subject, 'fields.page.fields.relatedResources').safeArray.find((r) => r.sys.id === db.sys.id) ||
-                typy(subject, 'fields.page.fields.relatedExtraSections').safeArray.find((section) => (
-                  typy(section, 'fields.links').safeArray.find((r) => r.sys.id === db.sys.id)
-                ))
+            const canFavorite = (obj) => {
+              return typy(obj, 'sys.contentType.sys.id').safeString === 'resource' || typy(obj, 'fields.canFavorite').safeBoolean
+            }
+            const relatedDbs = []
+            this.state.data[FAVORITES_KIND.subjects].forEach((subject) => {
+              typy(subject, 'fields.page.fields.relatedResources').safeArray.forEach((r) => {
+                if (canFavorite(r)) {
+                  relatedDbs.push(r)
+                }
+              })
+              typy(subject, 'fields.page.fields.relatedExtraSections').safeArray.forEach((section) => (
+                typy(section, 'fields.links').safeArray.forEach((r) => {
+                  if (canFavorite(r)) {
+                    relatedDbs.push(r)
+                  }
+                })
               ))
-            ))
+            })
             const existingFavorites = typy(this.props.favorites, `${FAVORITES_KIND.databases}.items`).safeArray
             // Convert the related dbs to match the favorites model, then remove any which are already favorites, and finally sort them
             const newDbs = helper.sortList(

--- a/src/tests/actions/personal/favorites.test.js
+++ b/src/tests/actions/personal/favorites.test.js
@@ -1,0 +1,545 @@
+import {
+  getFavorites,
+  getAllFavorites,
+  addFavorite,
+  removeFavorite,
+  setFavorites,
+  clearUpdateFavorites,
+  clearAllFavorites,
+  convertContentfulToFavorites,
+  searchFavorites,
+  KIND,
+  RECEIVE_FAVORITES,
+  REQUEST_FAVORITES,
+  RECEIVE_UPDATE_FAVORITES,
+  REQUEST_UPDATE_FAVORITES,
+  RECEIVE_SEARCH_FAVORITES,
+  REQUEST_SEARCH_FAVORITES,
+} from 'actions/personal/favorites'
+import { REQUEST_UPDATE_SETTINGS, DEFAULT_LIBRARY, KIND as SETTINGS_KIND } from 'actions/personal/settings'
+import Config from 'shared/Configuration'
+import configureMockStore from 'redux-mock-store'
+import nock from 'nock'
+import thunk from 'redux-thunk'
+import * as statuses from 'constants/APIStatuses'
+
+const middlewares = [ thunk ]
+const mockStore = configureMockStore(middlewares)
+
+const state = {
+  personal: {
+    login: {
+      token: 'fake token',
+    },
+  },
+}
+
+const favoriteResponse = {
+  key: 'link-1',
+  title: 'test',
+  url: 'http://www.link.url/',
+}
+
+const favoritesResponse = [ favoriteResponse ]
+
+const contentfulInternalLinks = [
+  {
+    sys: {
+      id: '123',
+      contentType: {
+        sys: { id: 'internalLink' }
+      },
+    },
+    fields: {
+      usePageTitle: true,
+      page: {
+        sys: { id: 'somePage' },
+        fields: {
+          title: 'use me',
+          slug: 'path/goes/here'
+        }
+      },
+      title: 'not me',
+    },
+    order: 12,
+  },
+]
+
+const contentfulResources = [
+  {
+    sys: {
+      id: '456',
+      contentType: {
+        sys: { id: 'resource' }
+      },
+    },
+    fields: {
+      urls: [
+        {
+          title: 'link 1',
+          url: 'the/link',
+        },
+        {
+          title: 'link 2',
+          url: 'is/here',
+        }
+      ],
+      title: 'db',
+    },
+  }
+]
+
+const contentfulExternalLinks = [
+  {
+    sys: {
+      id: '789',
+      contentType: {
+        sys: { id: 'externalLink' }
+      },
+    },
+    fields: {
+      url: 'link/path/here',
+      title: 'title me',
+    },
+  },
+]
+
+describe('favorites fetch action creator', () => {
+  beforeEach(() => {
+    nock(Config.userPrefsAPI)
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        "Access-Control-Allow-Headers": "Authorization",
+        "Content-Type": "application:json",
+      })
+      .intercept(() => true, 'OPTIONS')
+      .reply(204, null)
+      .persist()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  afterAll(() => {
+    nock.restore()
+  })
+
+  describe('getFavorites', () => {
+    describe('on success', () => {
+      beforeEach(() => {
+        nock(Config.userPrefsAPI)
+          .get(/favorites/)
+          .reply(200, favoritesResponse)
+          .persist()
+      })
+
+      it('should first create a REQUEST_FAVORITES action', () => {
+        const type = KIND.subjects
+        const expectedAction = {
+          type: REQUEST_FAVORITES,
+          kind: type,
+        }
+
+        const store = mockStore(state)
+        store.dispatch(getFavorites(type))
+        expect(store.getActions()[0]).toMatchObject(expectedAction)
+      })
+
+      it('should create a RECEIVE_FAVORITES action', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_FAVORITES,
+          kind: type,
+          state: statuses.SUCCESS,
+          items: favoritesResponse,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(getFavorites(type))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+
+    describe('on error', () => {
+      beforeEach(() => {
+        nock(Config.userPrefsAPI)
+          .get(/favorites/)
+          .reply(401)
+          .persist()
+      })
+
+      it('should create a RECEIVE_FAVORITES action with a status of error', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_FAVORITES,
+          kind: type,
+          state: statuses.ERROR,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(getFavorites(type))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+  })
+
+  describe('addFavorite', () => {
+    describe('on success', () => {
+      beforeEach(() => {
+        nock(Config.userPrefsAPI)
+          .post(/favorites/)
+          .reply(200, favoriteResponse)
+          .persist()
+      })
+
+      it('should first create a REQUEST_UPDATE_FAVORITES action', () => {
+        const type = KIND.subjects
+        const expectedAction = {
+          type: REQUEST_UPDATE_FAVORITES,
+          kind: type,
+        }
+
+        const store = mockStore(state)
+        store.dispatch(addFavorite(type, 'key', 'title', 'url'))
+        expect(store.getActions()[0]).toMatchObject(expectedAction)
+      })
+
+      it('should create a RECEIVE_UPDATE_FAVORITES action', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_UPDATE_FAVORITES,
+          kind: type,
+          state: statuses.SUCCESS,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(addFavorite(type, 'key', 'title', 'url'))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+
+    describe('on error', () => {
+      beforeEach(() => {
+        nock(Config.userPrefsAPI)
+          .post(/favorites/)
+          .reply(401)
+          .persist()
+      })
+
+      it('should create a RECEIVE_UPDATE_FAVORITES action with a status of error', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_UPDATE_FAVORITES,
+          kind: type,
+          state: statuses.ERROR,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(addFavorite(type, 'key', 'title', 'url'))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+  })
+
+  describe('removeFavorite', () => {
+    describe('on success', () => {
+      beforeEach(() => {
+        nock(Config.userPrefsAPI)
+          .delete(/favorites/)
+          .reply(200, favoritesResponse)
+          .persist()
+      })
+
+      it('should first create a REQUEST_UPDATE_FAVORITES action', () => {
+        const type = KIND.subjects
+        const expectedAction = {
+          type: REQUEST_UPDATE_FAVORITES,
+          kind: type,
+        }
+
+        const store = mockStore(state)
+        store.dispatch(removeFavorite(type, 'key'))
+        expect(store.getActions()[0]).toMatchObject(expectedAction)
+      })
+
+      it('should create a RECEIVE_UPDATE_FAVORITES action', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_UPDATE_FAVORITES,
+          kind: type,
+          state: statuses.SUCCESS,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(removeFavorite(type, 'key'))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+
+    describe('on error', () => {
+      beforeEach(() => {
+        nock(Config.userPrefsAPI)
+          .delete(/favorites/)
+          .reply(401)
+          .persist()
+      })
+
+      it('should create a RECEIVE_UPDATE_FAVORITES action with a status of error', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_UPDATE_FAVORITES,
+          kind: type,
+          state: statuses.ERROR,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(removeFavorite(type, 'key'))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+  })
+
+  describe('setFavorites', () => {
+    describe('on success', () => {
+      beforeEach(() => {
+        nock(Config.userPrefsAPI)
+          .post(/favorites/)
+          .reply(200, favoritesResponse)
+          .persist()
+      })
+
+      it('should first create a REQUEST_UPDATE_FAVORITES action', () => {
+        const type = KIND.subjects
+        const expectedAction = {
+          type: REQUEST_UPDATE_FAVORITES,
+          kind: type,
+        }
+
+        const store = mockStore(state)
+        store.dispatch(setFavorites(type, favoritesResponse))
+        expect(store.getActions()[0]).toMatchObject(expectedAction)
+      })
+
+      it('should create a RECEIVE_UPDATE_FAVORITES action', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_UPDATE_FAVORITES,
+          kind: type,
+          state: statuses.SUCCESS,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(setFavorites(type, favoritesResponse))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+
+    describe('on error', () => {
+      beforeEach(() => {
+        nock(Config.userPrefsAPI)
+          .post(/favorites/)
+          .reply(401)
+          .persist()
+      })
+
+      it('should create a RECEIVE_UPDATE_FAVORITES action with a status of error', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_UPDATE_FAVORITES,
+          kind: type,
+          state: statuses.ERROR,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(setFavorites(type, favoritesResponse))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+  })
+
+  describe('clearAllFavorites', () => {
+    beforeEach(() => {
+      nock(Config.userPrefsAPI)
+        .post(() => true)
+        .reply(200, '')
+        .persist()
+    })
+
+    it('should send actions to the store for each favorite setting', () => {
+      const store = mockStore(state)
+      return store.dispatch(clearAllFavorites())
+        .then(() => {
+          expect(store.getActions()).toEqual(expect.arrayContaining([
+            {
+              type: REQUEST_UPDATE_FAVORITES,
+              kind: KIND.databases,
+            },
+            {
+              type: REQUEST_UPDATE_FAVORITES,
+              kind: KIND.subjects,
+            },
+            {
+              type: REQUEST_UPDATE_SETTINGS,
+              kind: SETTINGS_KIND.homeLibrary,
+            },
+            {
+              type: REQUEST_UPDATE_SETTINGS,
+              kind: SETTINGS_KIND.hideHomeFavorites,
+            },
+            {
+              type: REQUEST_UPDATE_SETTINGS,
+              kind: SETTINGS_KIND.defaultSearch,
+            },
+          ]))
+        })
+    })
+  })
+
+  describe('searchFavorites', () => {
+    describe('on success', () => {
+      beforeEach(() => {
+        nock(Config.contentfulAPI)
+          .defaultReplyHeaders({ 'Access-Control-Allow-Origin': '*' })
+          .get('/query')
+          .query(fullQuery => fullQuery.query.includes('content_type=resource'))
+          .reply(200, contentfulResources)
+          .get('/query')
+          .query(fullQuery => fullQuery.query.includes('content_type=externalLink'))
+          .reply(200, contentfulExternalLinks)
+          .get('/query')
+          .query(fullQuery => fullQuery.query.includes('content_type=internalLink'))
+          .reply(200, contentfulInternalLinks)
+          .persist()
+      })
+
+      it('should first create a REQUEST_SEARCH_FAVORITES action', () => {
+        const type = KIND.subjects
+        const expectedAction = {
+          type: REQUEST_SEARCH_FAVORITES,
+          kind: type,
+        }
+
+        const store = mockStore(state)
+        store.dispatch(searchFavorites(type, 'search text'))
+        expect(store.getActions()[0]).toMatchObject(expectedAction)
+      })
+
+      it('should receive subject favorites from Contentful', () => {
+        const type = KIND.subjects
+        const expectedAction = {
+          type: RECEIVE_SEARCH_FAVORITES,
+          kind: type,
+          state: statuses.SUCCESS,
+          searchText: 'search text',
+          results: convertContentfulToFavorites(contentfulInternalLinks, type),
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(searchFavorites(type, 'search text'))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+
+      it('should receive database favorites from Contentful', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_SEARCH_FAVORITES,
+          kind: type,
+          state: statuses.SUCCESS,
+          searchText: 'search text',
+          results: convertContentfulToFavorites(contentfulResources.concat(contentfulExternalLinks), type),
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(searchFavorites(type, 'search text'))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+
+    describe('on error', () => {
+      beforeEach(() => {
+        nock(Config.contentfulAPI)
+          .defaultReplyHeaders({ 'Access-Control-Allow-Origin': '*' })
+          .get(() => true)
+          .reply(401)
+          .persist()
+      })
+
+      it('should create a RECEIVE_FAVORITES action with a status of error', () => {
+        const type = KIND.databases
+        const expectedAction = {
+          type: RECEIVE_SEARCH_FAVORITES,
+          kind: type,
+          state: statuses.ERROR,
+        }
+
+        const store = mockStore(state)
+        return store.dispatch(searchFavorites(type, 'search text'))
+          .then(() => {
+            expect(store.getActions()).toEqual(expect.arrayContaining([expect.objectContaining(expectedAction)]))
+          })
+      })
+    })
+  })
+
+  describe('convertContentfulToFavorites', () => {
+    it('should convert subject correctly', () => {
+      const result = convertContentfulToFavorites(contentfulInternalLinks, KIND.subjects)
+      expect(result).toEqual([
+        {
+          itemKey: '123',
+          title: 'use me',
+          url: '/path/goes/here',
+          order: 12,
+        },
+      ])
+    })
+
+    it('should convert database with multiple urls correctly', () => {
+      const result = convertContentfulToFavorites(contentfulResources, KIND.databases)
+      expect(result).toEqual([
+        {
+          itemKey: '456_link_0',
+          title: 'db - link 1',
+          url: 'the/link',
+        },
+        {
+          itemKey: '456_link_1',
+          title: 'db - link 2',
+          url: 'is/here',
+        },
+      ])
+    })
+
+    it('should convert external link correctly', () => {
+      const result = convertContentfulToFavorites(contentfulExternalLinks, KIND.databases)
+      expect(result).toEqual([
+        {
+          itemKey: '789_link_0',
+          title: 'title me',
+          url: 'link/path/here',
+        },
+      ])
+    })
+  })
+})

--- a/src/tests/components/Account/Favorites/Wizard/index.test.js
+++ b/src/tests/components/Account/Favorites/Wizard/index.test.js
@@ -231,7 +231,8 @@ describe('components/Account/Favorites/Wizard', () => {
                       sys: { id: 'DONT_CHANGE_ME' },
                       fields: {
                         title: 'LEAVE_ME_BE',
-                        purl: '/srsly',
+                        url: '/srsly',
+                        canFavorite: true,
                       },
                     },
                   ],


### PR DESCRIPTION
Simply put, when searching for databases to include in favorites, include items with the "externalLink" content type if they have the `canFavorite` flag set to true.