### PR TITLE
LW-906 Switch markdown-to-jsx to forked version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hoist-non-react-statics": "^3.3.0",
     "ie-array-find-polyfill": "^1.1.0",
     "isomorphic-fetch": "^2.2.1",
-    "markdown-to-jsx": "^6.10.0",
+    "@ndlib/markdown-to-jsx": "^6.11.2",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/src/components/LibMarkdown/index.js
+++ b/src/components/LibMarkdown/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import Markdown from 'markdown-to-jsx'
+import Markdown from '@ndlib/markdown-to-jsx'
 import PropTypes from 'prop-types'
 import Link from 'components/Interactive/Link'
 

--- a/src/tests/components/LibMarkdown/index.test.js
+++ b/src/tests/components/LibMarkdown/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Markdown from 'markdown-to-jsx'
+import Markdown from '@ndlib/markdown-to-jsx'
 import { shallow } from 'enzyme'
 import LibMarkdown from 'components/LibMarkdown'
 import Link from 'components/Interactive/Link'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,14 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@ndlib/markdown-to-jsx@^6.11.2":
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/@ndlib/markdown-to-jsx/-/markdown-to-jsx-6.11.2.tgz#ddd9432d0c5d86aefda01f734d66004e4b811db0"
+  integrity sha512-DA448cNivFBuFbd5qCGUJuOHvz/jp0zwXxf3htSoUnpGIz/VOrcc+kMbFBRPAepxU748Y0VTYWvyemWb9n7PhA==
+  dependencies:
+    prop-types "^15.6.2"
+    unquote "^1.1.0"
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
@@ -7152,14 +7160,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-markdown-to-jsx@^6.10.0:
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.10.2.tgz#644f602b81d088f10aef1c3674874876146cf38b"
-  integrity sha512-eDCsRobOkbQ4PqCphrxNi/U8geA8DGf52dMP4BrrYsVFyQ2ILFnXIB5sRcIxnRK2nPl8k5hUYdRNRXLlQNYLYg==
-  dependencies:
-    prop-types "^15.6.2"
-    unquote "^1.1.0"
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
The library maintainer was unresponsive to my PR, so I forked the project so we can render how we want to. This will give content editors more consistency between the Contentful preview and how content displays on the site.