### PR TITLE
Fix issue with best bets for certain subjects.

### DIFF
--- a/src/components/DatabaseList/Databases/BestBets/index.js
+++ b/src/components/DatabaseList/Databases/BestBets/index.js
@@ -9,7 +9,7 @@ import styles from './style.module.css'
 const BestBets = (props) => {
   // Group databases underneath the subject(s) they are best bets for
   const databasesBySubject = {}
-  props.subjects.filter(subject => props.subjectFilter.includes(subject.sys.id)).forEach(subject => {
+  props.subjects.filter(subject => props.subjectFilter.includes(subject.fields.id)).forEach(subject => {
     const matchingDbs = props.databases.filter(db => typy(db.fields, 'bestBets').safeArray.some(search => search.sys.id === subject.sys.id))
     if (matchingDbs.length) {
       databasesBySubject[subject.linkText] = matchingDbs

--- a/src/tests/components/DatabaseList/Databases/BestBets/index.test.js
+++ b/src/tests/components/DatabaseList/Databases/BestBets/index.test.js
@@ -30,6 +30,9 @@ describe('components/DatabaseList/Databases/BestBets', () => {
             subjects: [
               {
                 sys: {
+                  id: 'sys_doge',
+                },
+                fields: {
                   id: 'doge',
                 },
               },
@@ -37,6 +40,9 @@ describe('components/DatabaseList/Databases/BestBets', () => {
             bestBets: [
               {
                 sys: {
+                  id: 'sys_doge',
+                },
+                fields: {
                   id: 'doge',
                 },
               },
@@ -51,6 +57,9 @@ describe('components/DatabaseList/Databases/BestBets', () => {
             subjects: [
               {
                 sys: {
+                  id: 'sys_woof',
+                },
+                fields: {
                   id: 'woof',
                 },
               },
@@ -61,24 +70,36 @@ describe('components/DatabaseList/Databases/BestBets', () => {
       subjects: [
         {
           sys: {
+            id: 'sys_doge',
+          },
+          fields: {
             id: 'doge',
           },
           linkText: 'Doge',
         },
         {
           sys: {
+            id: 'sys_woof',
+          },
+          fields: {
             id: 'woof',
           },
           linkText: 'Woof',
         },
         {
           sys: {
-            id: 'notMeow',
+            id: 'sys_notMeow',
+          },
+          fields: {
+            fields: 'notMeow',
           },
           linkText: 'Not a Meow',
         },
         {
           sys: {
+            id: 'sys_bark',
+          },
+          fields: {
             id: 'bark',
           },
           linkText: 'Bark',


### PR DESCRIPTION
Subjects have a field called "id" since we needed a user-friendly identifier for query strings and `sys.id` isn't modifiable. We just have to actually use the right id in the right place. :)