### PR TITLE
LW-1064 Refactor chat so it will show custom offline text.

### DIFF
--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Helmet } from 'react-helmet'
 
 const Chat = () => {
   return (
@@ -6,19 +7,10 @@ const Chat = () => {
       <div className='skiplink'>
         Phone Number: <a href='tel:5746316679' aria-label='Call (574) 631-6679'>(574) 631-6679</a>
       </div>
-      <div className='libraryh3lp' aria-hidden='true'>
-        <iframe
-          title='Chat with Us'
-          src='https://libraryh3lp.com/chat/nd-ask-a-lib@chat.libraryh3lp.com?skin=10273'
-          frameBorder={0}
-          style={{
-            width: '100%',
-            height:' 45vh',
-            border: '0px',
-            inset: '#2a4480',
-          }}
-        />
-      </div>
+      <div className='libraryh3lp needs-js' aria-hidden='true' />
+      <Helmet>
+        <script type='text/javascript' src='https://libraryh3lp.com/js/libraryh3lp.js?16990' async />
+      </Helmet>
     </section>
   )
 }

--- a/src/tests/components/Chat/index.test.js
+++ b/src/tests/components/Chat/index.test.js
@@ -17,9 +17,9 @@ describe('components/Chat', () => {
     enzymeWrapper = setup()
   })
 
-  it('should render an iframe to libraryh3lp', () => {
-    const iframe = enzymeWrapper.find('iframe')
-    expect(iframe.exists()).toBe(true)
-    expect(iframe.props().src).toEqual(expect.stringContaining('libraryh3lp.com'))
+  it('should render a script from libraryh3lp', () => {
+    const script = enzymeWrapper.find('script')
+    expect(script.exists()).toBe(true)
+    expect(script.props().src).toEqual(expect.stringContaining('libraryh3lp.com'))
   })
 })


### PR DESCRIPTION
The iframe approach wouldn't really work because we need to customize the display when chat is offline. The only way to identify that is to use libraryh3lp's built-in customization, which requires that we call their script instead of just calling the iframe directly.

Ultimately the script still embeds an iframe if chat is online, but it lets us specify custom HTML (in their admin UI) when it is offline.