### PR TITLE
LW-1121 Add dynamic page for study spaces and sort listing.

### DIFF
--- a/src/actions/contentful/staticContent.js
+++ b/src/actions/contentful/staticContent.js
@@ -14,7 +14,7 @@ export const CF_RECEIVE_SIDEBAR = 'CF_RECEIVE_SIDEBAR'
 const receiveSidebar = (slug, response) => {
   const error = {
     type: CF_RECEIVE_SIDEBAR,
-    status: response.status === 404 ? statuses.NOT_FOUND : statuses.ERROR,
+    status: (response.status === 404 || response.length === 0) ? statuses.NOT_FOUND : statuses.ERROR,
     error: response,
     slug: slug,
     receivedAt: Date.now(),
@@ -29,7 +29,7 @@ const receiveSidebar = (slug, response) => {
   }
 
   try {
-    if (response[0] && response[0].sys.contentType.sys.id === 'dynamicPage') {
+    if (response.length > 0 && response[0].sys.contentType.sys.id === 'dynamicPage') {
       return success
     } else {
       return error

--- a/src/components/LandingPages/StudySpaces/presenter.js
+++ b/src/components/LandingPages/StudySpaces/presenter.js
@@ -7,7 +7,8 @@ import SpaceCard from 'components/SpaceCard'
 const Presenter = (props) => {
   return (
     <LandingPageWrapper
-      pageTitle='Study Spaces'
+      slug='study-spaces'
+      pageTitle='Hesburgh Library Study Spaces'
       entries={props.spaces}
       filteredEntries={props.spaces}
       location={props.location}
@@ -16,7 +17,7 @@ const Presenter = (props) => {
       facets={props.facets}
       entryCardComponent={SpaceCard}
       filterFields={['fields.name', 'fields.description', 'fields.features[*]']}
-      sortFields={['fields.name']}
+      sortFields={['fields.floor.fields.floorNumber', 'fields.name']}
     />
   )
 }

--- a/src/components/LandingPages/Wrapper/presenter.js
+++ b/src/components/LandingPages/Wrapper/presenter.js
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types'
 import typy from 'typy'
 
 import ActiveFilters from './ActiveFilters'
+import LibMarkdown from 'components/LibMarkdown'
 import PageTitle from 'components/Layout/PageTitle'
 import SearchProgramaticSet from 'components/SearchProgramaticSet'
 import Link from 'components/Interactive/Link'
 import FilterBox from 'components/Interactive/FilterBox'
 import Facet from 'components/Interactive/Facet'
+import StaticAlert from 'components/Contentful/StaticContent/Alert'
+import StaticBody from 'components/Contentful/StaticContent/Body'
 
 import './style.css'
 
@@ -20,10 +23,13 @@ const Presenter = (props) => {
       { props.linkPath && (
         <Link to={props.linkPath} className='button fright tab'>{props.linkText}</Link>
       )}
-      <PageTitle title={props.pageTitle} />
+      <PageTitle title={typy(props.dynamicPage, 'fields.title').safeString || props.pageTitle} />
       <SearchProgramaticSet open={false} />
       <div className='row'>
         <div className={`col-md-8 col-sm-7 col-xs-12 landing-page-list ${classPrefix}-list`}>
+          { props.slug && (
+            <StaticAlert slug={props.slug} preview={props.preview} hideLoading />
+          )}
           <FilterBox value={props.filterValue} title={'Search ' + props.typeLabel} onChange={props.onFilterChange} />
           { hasFacets && (
             <ActiveFilters values={props.facetValues} onRemove={props.onFacetRemove} />
@@ -50,6 +56,11 @@ const Presenter = (props) => {
               </div>
             )
           }
+          { props.slug && (
+            <StaticBody slug={props.slug} preview={props.preview} hideLoading>
+              <LibMarkdown>{typy(props.dynamicPage, 'fields.body').safeString}</LibMarkdown>
+            </StaticBody>
+          )}
         </div>
         <div className={`col-md-4 col-sm-5 col-xs-12 right landing-page-sidebar ${classPrefix}-sidebar`}>
           { props.children }
@@ -77,7 +88,7 @@ const Presenter = (props) => {
 Presenter.propTypes = {
   linkPath: PropTypes.string,
   linkText: PropTypes.string,
-  pageTitle: PropTypes.string.isRequired,
+  pageTitle: PropTypes.string,
   entries: PropTypes.array,
   onFilterChange: PropTypes.func.isRequired,
   filterValue: PropTypes.string,
@@ -97,6 +108,9 @@ Presenter.propTypes = {
     })),
   })),
   facetValues: PropTypes.object.isRequired,
+  slug: PropTypes.string,
+  preview: PropTypes.bool,
+  dynamicPage: PropTypes.object,
 }
 
 export default Presenter

--- a/src/constants/HelperFunctions.js
+++ b/src/constants/HelperFunctions.js
@@ -1,4 +1,4 @@
-/* eslint complexity: ["warn", 15] */
+/* eslint complexity: ["warn", 20] */
 // Helper functions are not something that should need regular maintenance. They should "just work",
 // and their inner-workings often need to be complex to accommodate generic usage.
 
@@ -73,6 +73,8 @@ const sortInternal = (a, b, sortKeys, sortDir) => {
     result = (!!aValue - !!bValue) * direction // falsy values will be given lower priority in asc and higher in desc
   } else if (aValue instanceof Date && bValue instanceof Date) {
     result = (aValue.getTime() - bValue.getTime()) * direction
+  } else if (typy(aValue).isNumber && typy(bValue).isNumber) {
+    result = aValue - bValue * direction
   } else {
     result = aValue.toString() // works on numbers and puts them at the top (asc) or bottm (desc)
       .localeCompare(bValue, undefined, { sensitivity: 'accent', ignorePunctuation: true }) * direction

--- a/src/tests/components/LandingPages/StudySpaces/index.test.js
+++ b/src/tests/components/LandingPages/StudySpaces/index.test.js
@@ -1,0 +1,139 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import { SpacesContainer, mapStateToProps, mapDispatchToProps } from 'components/LandingPages/StudySpaces'
+import Presenter from 'components/LandingPages/StudySpaces/presenter'
+
+import * as statuses from 'constants/APIStatuses'
+
+let enzymeWrapper
+let props
+
+const setup = (props) => {
+  return shallow(<SpacesContainer {...props} />)
+}
+
+describe('components/LandingPages/Exhibits/Current', () => {
+  afterEach(() => {
+    enzymeWrapper = undefined
+    props = undefined
+  })
+
+  describe('before fetching data', () => {
+    beforeEach(() => {
+      props = {
+        spaces: [],
+        allSpacesStatus: statuses.NOT_FETCHED,
+        facetStatus: statuses.NOT_FETCHED,
+        combinedStatus: statuses.NOT_FETCHED,
+        facets: [],
+        fetchAllSpaces: jest.fn(),
+        fetchGrouping: jest.fn(),
+        location: {
+          search: '?preview=true'
+        },
+      }
+      enzymeWrapper = setup(props)
+    })
+
+    it('should call fetchAllSpaces with preview flag', () => {
+      expect(props.fetchAllSpaces).toHaveBeenCalledWith(true)
+    })
+
+    it('should call fetchGrouping (to get facets) with preview flag', () => {
+      expect(props.fetchGrouping).toHaveBeenCalledWith(expect.any(String), true, expect.any(Number))
+    })
+
+    it('should render presenter', () => {
+      expect(enzymeWrapper.find(Presenter).exists()).toBe(true)
+    })
+  })
+
+  describe('after fetching data', () => {
+    beforeEach(() => {
+      props = {
+        spaces: [],
+        allSpacesStatus: statuses.SUCCESS,
+        facetStatus: statuses.SUCCESS,
+        combinedStatus: statuses.SUCCESS,
+        facets: [],
+        fetchAllSpaces: jest.fn(),
+        fetchGrouping: jest.fn(),
+        location: {
+          search: '?preview=true'
+        },
+      }
+      enzymeWrapper = setup(props)
+    })
+
+    it('should not call fetchAllSpaces', () => {
+      expect(props.fetchAllSpaces).not.toHaveBeenCalled()
+    })
+
+    it('should not call fetchGrouping', () => {
+      expect(props.fetchGrouping).not.toHaveBeenCalled()
+    })
+
+    it('should render presenter', () => {
+      expect(enzymeWrapper.find(Presenter).exists()).toBe(true)
+    })
+  })
+
+  describe('mapStateToProps', () => {
+    beforeEach(() => {
+      props = {
+        location: {
+          search: '?preview=false'
+        },
+        match: {
+          params: {
+            date: null,
+          },
+        },
+      }
+    })
+
+    it('should provide safe defaults', () => {
+      const state = {
+        allSpaces: {
+          status: statuses.FETCHING,
+        },
+      }
+      const result = mapStateToProps(state, props)
+      expect(result).toEqual(expect.objectContaining({
+        spaces: [],
+        allSpacesStatus: state.allSpaces.status,
+        facetStatus: statuses.NOT_FETCHED,
+        combinedStatus: state.allSpaces.status,
+        facets: [],
+      }))
+    })
+  })
+
+  describe('mapDispatchToProps', () => {
+    const middlewares = [ thunk ]
+    const mockStore = configureMockStore(middlewares)
+    let store
+
+    beforeEach(() => {
+      const state = {
+        allSpaces: {
+          status: statuses.SUCCESS,
+        },
+      }
+      store = mockStore(state)
+    })
+
+    afterEach(() => {
+      store = undefined
+    })
+
+    it('should create expected action functions', () => {
+      const result = mapDispatchToProps(store.dispatch)
+      expect(result.fetchAllSpaces).toEqual(expect.any(Function))
+      expect(result.fetchGrouping).toEqual(expect.any(Function))
+    })
+  })
+})

--- a/src/tests/components/LandingPages/StudySpaces/presenter.test.js
+++ b/src/tests/components/LandingPages/StudySpaces/presenter.test.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import Presenter from 'components/LandingPages/StudySpaces/presenter'
+import LandingPageWrapper from 'components/LandingPages/Wrapper'
+
+import * as statuses from 'constants/APIStatuses'
+
+let enzymeWrapper
+let props
+
+const setup = (props) => {
+  return shallow(<Presenter {...props} />)
+}
+
+describe('components/LandingPages/StudySpaces/presenter', () => {
+  afterEach(() => {
+    enzymeWrapper = undefined
+    props = undefined
+  })
+
+  beforeEach(() => {
+    props = {
+      spaces: [
+        {
+          id: 'some space',
+          title: 'something',
+        },
+      ],
+      combinedStatus: statuses.SUCCESS,
+      facets: [
+        {
+          some: 'facet',
+        },
+      ],
+      location: {
+        search: '?type=test',
+      },
+      history: {},
+      match: {
+        params: {},
+      },
+    }
+    enzymeWrapper = setup(props)
+  })
+
+  it('should render correct LandingPageWrapper', () => {
+    const wrapper = enzymeWrapper.find(LandingPageWrapper)
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.props().entries).toEqual(props.spaces)
+    expect(wrapper.props().filteredEntries).toEqual(props.spaces)
+    expect(wrapper.props().allEntriesStatus).toEqual(props.combinedStatus)
+    expect(wrapper.props().facets).toEqual(props.facets)
+  })
+})

--- a/src/tests/components/LandingPages/Wrapper/index.test.js
+++ b/src/tests/components/LandingPages/Wrapper/index.test.js
@@ -5,7 +5,7 @@ import thunk from 'redux-thunk'
 
 import LandingPageWrapper, { LandingPageWrapperContainer, mapStateToProps, mapDispatchToProps } from 'components/LandingPages/Wrapper'
 import Presenter from 'components/LandingPages/Wrapper/presenter'
-import PresenterFactory from 'components/APIInlinePresenterFactory'
+import PresenterFactory from 'components/APIPresenterFactory'
 
 import * as statuses from 'constants/APIStatuses'
 
@@ -94,6 +94,13 @@ describe('components/LandingPages/Wrapper', () => {
       history: {
         push: jest.fn(),
       },
+      preview: true,
+      slug: 'my-page-slug',
+      cfStatic: {
+        slug: 'old-slug',
+        status: statuses.SUCCESS,
+      },
+      fetchSidebar: jest.fn(),
     }
     enzymeWrapper = setup(props)
   })
@@ -109,6 +116,10 @@ describe('components/LandingPages/Wrapper', () => {
       entries: expect.arrayContaining(props.filteredEntries),
     }))
     expect(presenter.props().props.entries).toHaveLength(props.filteredEntries.length)
+  })
+
+  it('should fetch static content', () => {
+    expect(props.fetchSidebar).toHaveBeenCalled()
   })
 
   describe('filtering', () => {

--- a/src/tests/components/LandingPages/Wrapper/presenter.test.js
+++ b/src/tests/components/LandingPages/Wrapper/presenter.test.js
@@ -7,6 +7,9 @@ import PageTitle from 'components/Layout/PageTitle'
 import Link from 'components/Interactive/Link'
 import FilterBox from 'components/Interactive/FilterBox'
 import Facet from 'components/Interactive/Facet'
+import LibMarkdown from 'components/LibMarkdown'
+import StaticAlert from 'components/Contentful/StaticContent/Alert'
+import StaticBody from 'components/Contentful/StaticContent/Body'
 
 let enzymeWrapper
 let props
@@ -142,5 +145,45 @@ describe('components/LandingPages/Wrapper/presenter', () => {
     const facet = enzymeWrapper.findWhere(el => el.type() === Facet && el.props().name === 'type')
     expect(facet.exists()).toBe(true)
     expect(facet.props().selectedValues).toEqual(props.facetValues['type'])
+  })
+
+  it('should not render a StaticAlert component', () => {
+    expect(enzymeWrapper.find(StaticAlert).exists()).toBe(false)
+  })
+
+  it('should not render a StaticBody component', () => {
+    expect(enzymeWrapper.find(StaticBody).exists()).toBe(false)
+  })
+
+  describe('with static content for dynamic page', () => {
+    beforeEach(() => {
+      props = {
+        ...props,
+        slug: 'page-slug',
+        dynamicPage: {
+          fields: {
+            title: 'Dynamic page title',
+          },
+        },
+      }
+
+      enzymeWrapper = setup(props)
+    })
+
+    it('should use title from dynamic page', () => {
+      const title = enzymeWrapper.find(PageTitle)
+      expect(title.exists()).toBe(true)
+      expect(title.props().title).toEqual('Dynamic page title')
+    })
+
+    it('should render a StaticAlert component', () => {
+      expect(enzymeWrapper.find(StaticAlert).exists()).toBe(true)
+    })
+
+    it('should render a StaticBody component with markdown contents', () => {
+      const body = enzymeWrapper.find(StaticBody)
+      expect(body.exists()).toBe(true)
+      expect(body.find(LibMarkdown).exists()).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
This change allows all pages which use the LandingPageWrapper component to get a DynamicPage from Contentful simply by passing in the slug as a prop.

Fixed an issue with sorting integers so they sort naturally instead of as strings.