### PR TITLE
LW-1141 Fix chat box not showing on chat page.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,6 @@
       };
     </script>
     <script type="text/javascript" async src="https://app-script.monsido.com/v2/monsido-script.js"></script>
-    <script type="text/javascript" defer src="https://libraryh3lp.com/js/libraryh3lp.js?16990"></script>
 
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -6,7 +6,14 @@ const Chat = () => {
       <div className='skiplink'>
         Phone Number: <a href='tel:5746316679' aria-label='Call (574) 631-6679'>(574) 631-6679</a>
       </div>
-      <div className='libraryh3lp needs-js' aria-hidden='true' />
+      <div className='libraryh3lp needs-js' aria-hidden='true' data-lh3-jid='nd-ask-a-lib@chat.libraryh3lp.com'>
+        <iframe
+          src='https://libraryh3lp.com/chat/nd-ask-a-lib@chat.libraryh3lp.com?skin=10273'
+          title='Chat with a librarian'
+          frameBorder='0'
+          style={{ width: '100%', height: '425px', border: 0 }}
+        />
+      </div>
     </section>
   )
 }

--- a/src/components/Layout/Footer/FooterInfo/ChatModal/index.js
+++ b/src/components/Layout/Footer/FooterInfo/ChatModal/index.js
@@ -28,13 +28,14 @@ export const mapStateToProps = (state, ownProps) => {
     isLoggedIn: !!(personal.login.token),
     chatOptOut: [true, 'true'].includes(settings[SETTINGS_KIND.chatOptOut].data),
     chatOptOutFetchStatus: settings[SETTINGS_KIND.chatOptOut].state,
+    isChatPage: ['/chat', '/chat/'].includes(ownProps.location.pathname.toLowerCase()),
   }
 }
 
 export const mapDispatchToProps = (dispatch, ownProps) => {
   const onClick = (e, func) => {
     e.preventDefault()
-    if (ownProps.location.pathname === '/chat' || ownProps.location.pathname === '/chat/') {
+    if (ownProps.location.pathname.toLowerCase() === '/chat' || ownProps.location.pathname.toLowerCase() === '/chat/') {
       return
     }
 
@@ -98,7 +99,7 @@ export class ChatModalContainer extends Component {
 
   displayInvite () {
     // After time has elapsed, send proactive chat invite if chat is not already open
-    if (this.props.location.pathname !== '/chat' && this.props.location.pathname !== '/chat/' && !this.props.chatOpen) {
+    if (!this.props.isChatPage && !this.props.chatOpen) {
       // Make sure the user has not previously dismissed proactive chat
       let showInvite = true
       try {
@@ -132,7 +133,7 @@ export class ChatModalContainer extends Component {
   }
 
   render () {
-    if (this.props.location.pathname === '/chat' || this.props.location.pathname === '/chat/') {
+    if (this.props.isChatPage) {
       return null
     }
     return (
@@ -162,6 +163,7 @@ ChatModalContainer.propTypes = {
   isLoggedIn: PropTypes.bool,
   chatOptOut: PropTypes.bool,
   chatOptOutFetchStatus: PropTypes.string,
+  isChatPage: PropTypes.bool,
   getChatOptOut: PropTypes.func,
 }
 

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -4175,6 +4175,10 @@ section.group .modal-footer button {
   width: calc(100% - 32px); /* account for padding on parent container */
 }
 
+.libraryh3lp {
+  display: flex; /* prevents slight gap between bottom of iframe and container */
+}
+
 @media screen and (min-width: 62em) {
   .side-nav.column-md {
     display: inline;

--- a/src/tests/components/Chat/index.test.js
+++ b/src/tests/components/Chat/index.test.js
@@ -17,8 +17,9 @@ describe('components/Chat', () => {
     enzymeWrapper = setup()
   })
 
-  it('should render a placeholder div for libraryh3lp', () => {
-    const element = <div className='libraryh3lp needs-js' aria-hidden='true' />
-    expect(enzymeWrapper.containsMatchingElement(element)).toBe(true)
+  it('should render a div for libraryh3lp with iframe inside', () => {
+    const element = enzymeWrapper.findWhere(el => el.type() === 'div' && el.hasClass('libraryh3lp'))
+    expect(element.exists()).toBe(true)
+    expect(element.find('iframe').exists()).toBe(true)
   })
 })

--- a/src/tests/components/Layout/Footer/FooterInfo/ChatModal/index.test.js
+++ b/src/tests/components/Layout/Footer/FooterInfo/ChatModal/index.test.js
@@ -37,6 +37,7 @@ describe('components/Layout/Footer/FooterInfo/ChatModal', () => {
         isLoggedIn: true,
         chatOptOut: false,
         chatOptOutFetchStatus: statuses.NOT_FETCHED,
+        isChatPage: false,
       }
       enzymeWrapper = setup(props)
     })
@@ -111,6 +112,7 @@ describe('components/Layout/Footer/FooterInfo/ChatModal', () => {
         closeChat: jest.fn(),
         getChatOptOut: jest.fn(),
         isLoggedIn: true,
+        isChatPage: true,
       }
       enzymeWrapper = setup(props)
     })
@@ -144,6 +146,11 @@ describe('components/Layout/Footer/FooterInfo/ChatModal', () => {
     }
 
     it('should map props as expected', () => {
+      props = {
+        location: {
+          pathname: '/CHaT', // test case insensitive
+        },
+      }
       const result = mapStateToProps(state, props)
       expect(result).toMatchObject({
         chatOpen: false,
@@ -151,11 +158,15 @@ describe('components/Layout/Footer/FooterInfo/ChatModal', () => {
         isLoggedIn: true,
         chatOptOut: true,
         chatOptOutFetchStatus: statuses.SUCCESS,
+        isChatPage: true,
       })
     })
 
     it('should open chat page instead of modal when opened from keyboard', () => {
       props = {
+        location: {
+          pathname: '/anywhere',
+        },
         history: {
           push: jest.fn(),
         },


### PR DESCRIPTION
Sometimes opening the chat box didn't work, I think because of script execution order and a race condition. Ultimately all that the external javascript did was insert an iframe in the `.libraryh3lp` element, so I just cut that out of the process and placed the iframe directly in there. This seems to be more reliable.